### PR TITLE
Context references

### DIFF
--- a/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
+++ b/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
@@ -584,7 +584,7 @@ public class DecisionEngine {
 
             // if value not supplied, use the default and set it back into the context; if not supplied and no default, set the input the blank
             if (value == null) {
-                value = (input.getDefault() != null ? input.getDefault() : "");
+                value = (input.getDefault() != null ? translateValue(input.getDefault(), context) : "");
                 context.put(input.getKey(), value);
             }
 
@@ -620,7 +620,7 @@ public class DecisionEngine {
 
         // add all output keys to the context; if no default is supplied, use an empty string
         for (Entry<String, ? extends Output> entry : definition.getOutputMap().entrySet())
-            context.put(entry.getValue().getKey(), entry.getValue().getDefault() != null ? entry.getValue().getDefault() : "");
+            context.put(entry.getValue().getKey(), entry.getValue().getDefault() != null ? translateValue(entry.getValue().getDefault(), context) : "");
 
         // add the initial context
         if (definition.getInitialContext() != null)

--- a/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
+++ b/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
@@ -625,7 +625,7 @@ public class DecisionEngine {
         // add the initial context
         if (definition.getInitialContext() != null)
             for (KeyValue keyValue : definition.getInitialContext())
-                context.put(keyValue.getKey(), keyValue.getValue());
+                context.put(keyValue.getKey(), translateValue(keyValue.getValue(), context));
 
         // process each mapping if it is "involved", which is checked using the current context against inclusion/exclusion criteria
         if (definition.getMappings() != null) {

--- a/src/main/java/com/imsweb/staging/Staging.java
+++ b/src/main/java/com/imsweb/staging/Staging.java
@@ -32,6 +32,7 @@ import com.imsweb.staging.entities.StagingTablePath;
 public final class Staging {
 
     // context keys definitions
+    public static final String CTX_ALGORITHM_VERSION = "ctx_alg_version";
     public static final String CTX_YEAR_CURRENT = "ctx_year_current";
 
     // list of all context keys
@@ -554,6 +555,10 @@ public final class Staging {
      * @return updated Map of context
      */
     private Map<String, String> addContextKeys(Map<String, String> context) {
+        // make the algorithm version available in the context
+        context.put(CTX_ALGORITHM_VERSION, getVersion());
+
+        // put the current year in the context
         Calendar now = Calendar.getInstance();
         context.put(CTX_YEAR_CURRENT, String.valueOf(now.get(Calendar.YEAR)));
 

--- a/src/main/java/com/imsweb/staging/Staging.java
+++ b/src/main/java/com/imsweb/staging/Staging.java
@@ -4,8 +4,8 @@
 package com.imsweb.staging;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -36,7 +36,7 @@ public final class Staging {
     public static final String CTX_YEAR_CURRENT = "ctx_year_current";
 
     // list of all context keys
-    public static final List<String> CONTEXT_KEYS = Collections.singletonList(CTX_YEAR_CURRENT);
+    public static final List<String> CONTEXT_KEYS = Arrays.asList(CTX_ALGORITHM_VERSION, CTX_YEAR_CURRENT);
 
     private DecisionEngine _engine = null;
     private StagingDataProvider _provider = null;

--- a/src/test/java/com/imsweb/decisionengine/DecisionEngineTest.java
+++ b/src/test/java/com/imsweb/decisionengine/DecisionEngineTest.java
@@ -1333,7 +1333,36 @@ public class DecisionEngineTest {
     }
 
     @Test
-    public void testOutputsDefaultContextReferences() {
+    public void testInitialContextReferences() {
+        BasicDefinition def = new BasicDefinition("test_initial_context");
+        def.setOnInvalidInput(Definition.StagingInputErrorHandler.FAIL);
+
+        def.addInitialContext("a", "foo1");
+        def.addInitialContext("b", "{{foo1}}");
+        def.addInitialContext("c", "foo2");
+        def.addInitialContext("d", "{{foo2}}");
+        def.addInitialContext("e", "{{bad_key}}");
+
+        BasicDataProvider provider = new BasicDataProvider();
+        provider.addDefinition(def);
+        DecisionEngine engine = new DecisionEngine(provider);
+
+        Map<String, String> context = new HashMap<>();
+        context.put("foo1", "FIRST");
+        context.put("foo2", "SECOND");
+        Result result = engine.process("test_initial_context", context);
+
+        Assert.assertEquals(Type.STAGED, result.getType());
+
+        Assert.assertEquals(context.get("a"), "foo1");
+        Assert.assertEquals(context.get("b"), "FIRST");
+        Assert.assertEquals(context.get("c"), "foo2");
+        Assert.assertEquals(context.get("d"), "SECOND");
+        Assert.assertEquals(context.get("e"), "");
+    }
+
+    @Test
+    public void testInputsOutputsDefaultContextReferences() {
         BasicDefinition def = new BasicDefinition("test_context");
         def.setOnInvalidInput(Definition.StagingInputErrorHandler.FAIL);
 

--- a/src/test/java/com/imsweb/decisionengine/DecisionEngineTest.java
+++ b/src/test/java/com/imsweb/decisionengine/DecisionEngineTest.java
@@ -1347,7 +1347,7 @@ public class DecisionEngineTest {
         def.addInput(input);
 
         // add outputs
-        BasicOutput output = new BasicOutput("output1", "table_output");
+        BasicOutput output = new BasicOutput("output1");
         output.setDefault("foo2");
         def.addOutput(output);
 


### PR DESCRIPTION
This added support for context references in initial context, input defaults and output defaults.  They were already used in table processing.  One example where this would be helpful is setting `derived_version`.  Since you always want to use the current version you can set the value to `{{ctx_alg_version}}`.  `ctx_alg_version` is a new context variable added in the MR.