### PR TITLE
Updated the schema selection procedure.

### DIFF
--- a/src/main/java/com/imsweb/staging/SchemaLookup.java
+++ b/src/main/java/com/imsweb/staging/SchemaLookup.java
@@ -32,8 +32,10 @@ public class SchemaLookup {
      * @param histology histology
      */
     public SchemaLookup(String site, String histology) {
-        setInput(StagingData.PRIMARY_SITE_KEY, site);
-        setInput(StagingData.HISTOLOGY_KEY, histology);
+        if (site != null && !site.isEmpty())
+            setInput(StagingData.PRIMARY_SITE_KEY, site);
+        if (histology != null && !histology.isEmpty())
+            setInput(StagingData.HISTOLOGY_KEY, histology);
     }
 
     /**

--- a/src/main/java/com/imsweb/staging/SchemaLookup.java
+++ b/src/main/java/com/imsweb/staging/SchemaLookup.java
@@ -45,6 +45,14 @@ public class SchemaLookup {
     }
 
     /**
+     * Return a list of keys that are set
+     * @return a set of keys
+     */
+    public Set<String> getKeys() {
+        return _inputs.keySet();
+    }
+
+    /**
      * Return a Map of all inputs
      * @return a Map of all inputs
      */

--- a/src/test/java/com/imsweb/staging/SchemaLookupTest.java
+++ b/src/test/java/com/imsweb/staging/SchemaLookupTest.java
@@ -1,0 +1,28 @@
+package com.imsweb.staging;
+
+import java.util.HashSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SchemaLookupTest {
+
+    @Test
+    public void testConstructorMissingValues() {
+        assertEquals(new SchemaLookup().getKeys(), new HashSet<>());
+        assertEquals(new SchemaLookup(null, null).getKeys(), new HashSet<>());
+        assertEquals(new SchemaLookup("", null).getKeys(), new HashSet<>());
+        assertEquals(new SchemaLookup(null, "").getKeys(), new HashSet<>());
+        assertEquals(new SchemaLookup("", "").getKeys(), new HashSet<>());
+
+        assertEquals(new SchemaLookup("C629", null).getKeys(), Stream.of("site").collect(Collectors.toSet()));
+        assertEquals(new SchemaLookup("C629", "").getKeys(), Stream.of("site").collect(Collectors.toSet()));
+        assertEquals(new SchemaLookup(null, "9100").getKeys(), Stream.of("hist").collect(Collectors.toSet()));
+        assertEquals(new SchemaLookup("", "9100").getKeys(), Stream.of("hist").collect(Collectors.toSet()));
+        assertEquals(new SchemaLookup("C629", "9100").getKeys(), Stream.of("site", "hist").collect(Collectors.toSet()));
+    }
+
+}

--- a/src/test/java/com/imsweb/staging/cs/CsSchemaLookupTest.java
+++ b/src/test/java/com/imsweb/staging/cs/CsSchemaLookupTest.java
@@ -1,7 +1,11 @@
 package com.imsweb.staging.cs;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -23,6 +27,13 @@ public class CsSchemaLookupTest {
     public void testBadKey() {
         CsSchemaLookup lookup = new CsSchemaLookup("C509", "8000");
         lookup.setInput("bad_key", "111");
+    }
+
+    @Test
+    public void testGetKeys() {
+        assertEquals(new CsSchemaLookup("C629", "9100").getKeys(), Stream.of("site", "hist").collect(Collectors.toSet()));
+        assertEquals(new CsSchemaLookup("C629", "9100").getKeys(), Stream.of("site", "hist").collect(Collectors.toSet()));
+        assertEquals(new CsSchemaLookup("C629", "9100", "001").getKeys(), Stream.of("site", "hist", "ssf25").collect(Collectors.toSet()));
     }
 
 }

--- a/src/test/java/com/imsweb/staging/cs/CsStagingTest.java
+++ b/src/test/java/com/imsweb/staging/cs/CsStagingTest.java
@@ -143,11 +143,11 @@ public class CsStagingTest extends StagingTest {
         assertEquals(Integer.valueOf(138), lookup.get(0).getSchemaNum());
 
         // test searching on only site
-        lookup = _STAGING.lookupSchema(new CsSchemaLookup("C401", null, null));
+        lookup = _STAGING.lookupSchema(new CsSchemaLookup("C401", null));
         assertEquals(5, lookup.size());
 
         // test searching on only hist
-        lookup = _STAGING.lookupSchema(new CsSchemaLookup(null, "9702", null));
+        lookup = _STAGING.lookupSchema(new CsSchemaLookup(null, "9702"));
         assertEquals(2, lookup.size());
 
         // test that searching on only ssf25 returns no results

--- a/src/test/java/com/imsweb/staging/tnm/TnmStagingTest.java
+++ b/src/test/java/com/imsweb/staging/tnm/TnmStagingTest.java
@@ -3,8 +3,6 @@
  */
 package com.imsweb.staging.tnm;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,6 +34,11 @@ import static org.junit.Assert.assertTrue;
 
 public class TnmStagingTest extends StagingTest {
 
+    @BeforeClass
+    public static void init() {
+        _STAGING = Staging.getInstance(TnmDataProvider.getInstance(TnmDataProvider.TnmVersion.LATEST));
+    }
+
     @Override
     public String getAlgorithm() {
         return "tnm";
@@ -49,11 +52,6 @@ public class TnmStagingTest extends StagingTest {
     @Override
     public StagingFileDataProvider getProvider() {
         return TnmDataProvider.getInstance(TnmDataProvider.TnmVersion.LATEST);
-    }
-
-    @BeforeClass
-    public static void init() throws IOException {
-        _STAGING = Staging.getInstance(TnmDataProvider.getInstance(TnmDataProvider.TnmVersion.LATEST));
     }
 
     @Test
@@ -81,7 +79,7 @@ public class TnmStagingTest extends StagingTest {
     }
 
     @Test
-    public void testSchemaSelection() throws IOException, InterruptedException {
+    public void testSchemaSelection() {
         // test bad values
         List<StagingSchema> lookup = _STAGING.lookupSchema(new SchemaLookup());
         assertEquals(0, lookup.size());
@@ -451,7 +449,7 @@ public class TnmStagingTest extends StagingTest {
     }
 
     @Test
-    public void testEncoding() throws UnsupportedEncodingException {
+    public void testEncoding() {
         StagingTable table = _STAGING.getTable("thyroid_t_6166");
 
         assertNotNull(table);


### PR DESCRIPTION
Instead of matching on site/hist, then looping over results and matching on all fields, I know only match against the list of fields that were supplied in the call.

The current process is:

1. first match on all tables is using ONLY site/hist; it completely ignores any other INPUT columns
2. if there is one match, return it
3. if there are multiple matches, loop over all the matched tables
   - match table using ALL input columns.

with the upcoming EOD algorithm, there are multiple discriminators.  I am now simplifying the process to look like this:

1.  Match on all tables using only the keys that were supplied in the lookup.  