### PR TITLE
Support numeric range comparison

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     compile 'org.mongodb.morphia:morphia:1.3.2'
 
     compile 'com.github.ben-manes.caffeine:caffeine:2.6.0'
+    compile 'org.apache.commons:commons-lang3:3.7'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.unitils:unitils-core:3.4.6'

--- a/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
+++ b/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
@@ -135,16 +135,16 @@ public class DecisionEngine {
 
     /**
      * Tests that a value is contained in a list of ranges; if the list of ranges is missing or empty, then all values will match to it
-     * @param values a List of StringRange objects
+     * @param values a List of Range objects
      * @param value a value to look for
      * @param context the context will be used to do key lookups when values are in the format of {{var}}
-     * @return return true if the value is contained in the List of StringRange objects
+     * @return return true if the value is contained in the List of Range objects
      */
-    public static boolean testMatch(List<? extends StringRange> values, String value, Map<String, String> context) {
+    public static boolean testMatch(List<? extends Range> values, String value, Map<String, String> context) {
         boolean match = (values == null || values.isEmpty());
 
         if (!match) {
-            for (StringRange range : values) {
+            for (Range range : values) {
                 match = range.contains(value, context);
                 if (match)
                     break;

--- a/src/main/java/com/imsweb/decisionengine/Range.java
+++ b/src/main/java/com/imsweb/decisionengine/Range.java
@@ -8,7 +8,7 @@ import java.util.Map;
 /**
  * An interface representing a string range
  */
-public abstract class StringRange {
+public abstract class Range {
 
     /**
      * Returns true of the passed value is contained in the range

--- a/src/main/java/com/imsweb/decisionengine/TableRow.java
+++ b/src/main/java/com/imsweb/decisionengine/TableRow.java
@@ -13,9 +13,9 @@ public interface TableRow {
     /**
      * A list of values from the input column represented by the passed key
      * @param key the field name of the column
-     * @return a List of StringRange objects
+     * @return a List of Range objects
      */
-    List<? extends StringRange> getColumnInput(String key);
+    List<? extends Range> getColumnInput(String key);
 
     /**
      * A list of endpoints on the row

--- a/src/main/java/com/imsweb/staging/StagingDataProvider.java
+++ b/src/main/java/com/imsweb/staging/StagingDataProvider.java
@@ -29,10 +29,10 @@ import com.imsweb.decisionengine.DecisionEngine;
 import com.imsweb.decisionengine.Endpoint.EndpointType;
 import com.imsweb.staging.entities.StagingColumnDefinition;
 import com.imsweb.staging.entities.StagingEndpoint;
+import com.imsweb.staging.entities.StagingRange;
 import com.imsweb.staging.entities.StagingSchema;
 import com.imsweb.staging.entities.StagingSchemaInput;
 import com.imsweb.staging.entities.StagingSchemaOutput;
-import com.imsweb.staging.entities.StagingStringRange;
 import com.imsweb.staging.entities.StagingTable;
 import com.imsweb.staging.entities.StagingTableRow;
 
@@ -50,7 +50,7 @@ public abstract class StagingDataProvider implements DataProvider {
 
     private static final ObjectMapper _MAPPER = new ObjectMapper();
 
-    private static StagingStringRange _MATCH_ALL_ENDPOINT = new StagingStringRange();
+    private static StagingRange _MATCH_ALL_ENDPOINT = new StagingRange();
 
     static {
         _DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
@@ -153,12 +153,12 @@ public abstract class StagingDataProvider implements DataProvider {
                     switch (col.getType()) {
                         case INPUT:
                             // if there are no ranges in the list, that means the cell was "blank" and is not needed in the table row
-                            List<StagingStringRange> ranges = splitValues(cellValue);
+                            List<StagingRange> ranges = splitValues(cellValue);
                             if (!ranges.isEmpty()) {
                                 tableRowEntity.addInput(col.getKey(), ranges);
 
                                 // if there are key references used (values that reference other inputs) like {{key}}, then add them to the extra inputs list
-                                for (StagingStringRange range : ranges) {
+                                for (StagingRange range : ranges) {
                                     if (DecisionEngine.isReferenceVariable(range.getLow()))
                                         extraInputs.add(DecisionEngine.trimBraces(range.getLow()));
                                     if (DecisionEngine.isReferenceVariable(range.getHigh()))
@@ -226,12 +226,12 @@ public abstract class StagingDataProvider implements DataProvider {
     }
 
     /**
-     * Parses a string in having lists of ranges into a List of StringRange objects
+     * Parses a string in having lists of ranges into a List of Range objects
      * @param values String representing sets value ranges
      * @return a parsed list of string Range objects
      */
-    public static List<StagingStringRange> splitValues(String values) {
-        List<StagingStringRange> convertedRanges = new ArrayList<>();
+    public static List<StagingRange> splitValues(String values) {
+        List<StagingRange> convertedRanges = new ArrayList<>();
 
         if (values != null) {
             // if the value of the string is "*", then consider it as matching anything
@@ -251,12 +251,12 @@ public abstract class StagingDataProvider implements DataProvider {
                     if (parts.length == 2) {
                         // don't worry about length differences if one of the parts is a context variable
                         if (parts[0].trim().length() != parts[1].trim().length() && !DecisionEngine.isReferenceVariable(parts[0].trim()) && !DecisionEngine.isReferenceVariable(parts[1].trim()))
-                            convertedRanges.add(new StagingStringRange(range.trim(), range.trim()));
+                            convertedRanges.add(new StagingRange(range.trim(), range.trim()));
                         else
-                            convertedRanges.add(new StagingStringRange(parts[0].trim(), parts[1].trim()));
+                            convertedRanges.add(new StagingRange(parts[0].trim(), parts[1].trim()));
                     }
                     else
-                        convertedRanges.add(new StagingStringRange(range.trim(), range.trim()));
+                        convertedRanges.add(new StagingRange(range.trim(), range.trim()));
                 }
             }
         }
@@ -457,7 +457,7 @@ public abstract class StagingDataProvider implements DataProvider {
 
         String inputKey = inputKeys.iterator().next();
         for (StagingTableRow row : table.getTableRows()) {
-            for (StagingStringRange range : row.getColumnInput(inputKey)) {
+            for (StagingRange range : row.getColumnInput(inputKey)) {
                 if (range.getLow() != null) {
                     if (range.getLow().equals(range.getHigh()))
                         values.add(range.getLow());

--- a/src/main/java/com/imsweb/staging/entities/StagingRange.java
+++ b/src/main/java/com/imsweb/staging/entities/StagingRange.java
@@ -73,7 +73,7 @@ public class StagingRange extends Range {
     /**
      * Returns true if the value is contained in the range.  Note that the low and high values will be replaced with context if
      * they are specified that way.  There are two ways in which the values are compared.
-     * <p/>
+     * <p>
      * 1. If the low and high values aer different and are both "numeric", then the value will be compared using floats.
      * 2. Otherwise it will be compared using String but the strings must be the same length othersize the method will always return false.
      */

--- a/src/main/java/com/imsweb/staging/entities/StagingRange.java
+++ b/src/main/java/com/imsweb/staging/entities/StagingRange.java
@@ -74,8 +74,10 @@ public class StagingRange extends Range {
      * Returns true if the value is contained in the range.  Note that the low and high values will be replaced with context if
      * they are specified that way.  There are two ways in which the values are compared.
      * <p>
-     * 1. If the low and high values aer different and are both "numeric", then the value will be compared using floats.
-     * 2. Otherwise it will be compared using String but the strings must be the same length othersize the method will always return false.
+     * - If the low and high values ranges are different and are both "numeric", then the value will be compared using
+     * floats (which will work for the `Integer` type fields as well).
+     * <p>
+     * - Otherwise it will be compared using String but the strings must be the same length otherwise consider different
      */
     @Override
     public boolean contains(String value, Map<String, String> context) {

--- a/src/main/java/com/imsweb/staging/entities/StagingRange.java
+++ b/src/main/java/com/imsweb/staging/entities/StagingRange.java
@@ -47,6 +47,13 @@ public class StagingRange extends Range {
         _high = high;
     }
 
+    /**
+     * Return true if the string can converted into a number
+     */
+    public static boolean isNumeric(String value) {
+        return NumberUtils.isParsable(value);
+    }
+
     public String getLow() {
         return _low;
     }
@@ -63,10 +70,13 @@ public class StagingRange extends Range {
         return _low == null && _high == null;
     }
 
-    private boolean isNumeric(String value) {
-        return NumberUtils.isParsable(value);
-    }
-
+    /**
+     * Returns true if the value is contained in the range.  Note that the low and high values will be replaced with context if
+     * they are specified that way.  There are two ways in which the values are compared.
+     * <p/>
+     * 1. If the low and high values aer different and are both "numeric", then the value will be compared using floats.
+     * 2. Otherwise it will be compared using String but the strings must be the same length othersize the method will always return false.
+     */
     @Override
     public boolean contains(String value, Map<String, String> context) {
         if (matchesAll())

--- a/src/main/java/com/imsweb/staging/entities/StagingRange.java
+++ b/src/main/java/com/imsweb/staging/entities/StagingRange.java
@@ -81,7 +81,10 @@ public class StagingRange extends Range {
         String high = DecisionEngine.translateValue(_high, context);
 
         // if input, low and high values represent decimal numbers then do a float comparison
-        if (!low.equals(high) && isNumeric(low) && isNumeric(high) && isNumeric(value)) {
+        if (!low.equals(high) && isNumeric(low) && isNumeric(high)) {
+            if (!isNumeric(value))
+                return false;
+
             Float converted = NumberUtils.createFloat(value);
 
             return converted >= NumberUtils.createFloat(low) && converted <= NumberUtils.createFloat(high);

--- a/src/main/java/com/imsweb/staging/entities/StagingRange.java
+++ b/src/main/java/com/imsweb/staging/entities/StagingRange.java
@@ -81,7 +81,7 @@ public class StagingRange extends Range {
         String high = DecisionEngine.translateValue(_high, context);
 
         // if input, low and high values represent decimal numbers then do a float comparison
-        if (isNumeric(low) && isNumeric(high) && isNumeric(value)) {
+        if (!low.equals(high) && isNumeric(low) && isNumeric(high) && isNumeric(value)) {
             Float converted = NumberUtils.createFloat(value);
 
             return converted >= NumberUtils.createFloat(low) && converted <= NumberUtils.createFloat(high);

--- a/src/main/java/com/imsweb/staging/entities/StagingTableRow.java
+++ b/src/main/java/com/imsweb/staging/entities/StagingTableRow.java
@@ -19,22 +19,22 @@ import com.imsweb.decisionengine.TableRow;
 public class StagingTableRow implements TableRow {
 
     @Embedded("inputs")
-    private Map<String, List<StagingStringRange>> _inputs = new HashMap<>();
+    private Map<String, List<StagingRange>> _inputs = new HashMap<>();
     @Embedded("endpoints")
     private List<StagingEndpoint> _endpoints = new ArrayList<>();
 
     @Override
     @JsonIgnore
-    public List<StagingStringRange> getColumnInput(String key) {
+    public List<StagingRange> getColumnInput(String key) {
         return _inputs.get(key);
     }
 
     @JsonProperty("inputs")
-    public Map<String, List<StagingStringRange>> getInputs() {
+    public Map<String, List<StagingRange>> getInputs() {
         return _inputs;
     }
 
-    public void setInputs(Map<String, List<StagingStringRange>> inputs) {
+    public void setInputs(Map<String, List<StagingRange>> inputs) {
         _inputs = inputs;
     }
 
@@ -43,7 +43,7 @@ public class StagingTableRow implements TableRow {
      * @param key key
      * @param range range
      */
-    public void addInput(String key, List<StagingStringRange> range) {
+    public void addInput(String key, List<StagingRange> range) {
         _inputs.put(key, range);
     }
 

--- a/src/test/java/com/imsweb/decisionengine/DecisionEngineTest.java
+++ b/src/test/java/com/imsweb/decisionengine/DecisionEngineTest.java
@@ -25,7 +25,7 @@ import com.imsweb.decisionengine.basic.BasicEndpoint;
 import com.imsweb.decisionengine.basic.BasicInput;
 import com.imsweb.decisionengine.basic.BasicMapping;
 import com.imsweb.decisionengine.basic.BasicOutput;
-import com.imsweb.decisionengine.basic.BasicStringRange;
+import com.imsweb.decisionengine.basic.BasicRange;
 import com.imsweb.decisionengine.basic.BasicTable;
 import com.imsweb.decisionengine.basic.BasicTablePath;
 
@@ -291,16 +291,16 @@ public class DecisionEngineTest {
 
     @Test
     public void testMatch() {
-        List<StringRange> range = new ArrayList<>();
-        range.add(new BasicStringRange("1", "1"));
-        range.add(new BasicStringRange("4", "4"));
-        range.add(new BasicStringRange("9", "9"));
+        List<Range> range = new ArrayList<>();
+        range.add(new BasicRange("1", "1"));
+        range.add(new BasicRange("4", "4"));
+        range.add(new BasicRange("9", "9"));
         assertTrue(DecisionEngine.testMatch(range, "9", new HashMap<>()));
         assertFalse(DecisionEngine.testMatch(range, "7", new HashMap<>()));
 
         range = new ArrayList<>();
-        range.add(new BasicStringRange("11", "54"));
-        range.add(new BasicStringRange("99", "99"));
+        range.add(new BasicRange("11", "54"));
+        range.add(new BasicRange("99", "99"));
         assertTrue(DecisionEngine.testMatch(range, "23", new HashMap<>()));
     }
 

--- a/src/test/java/com/imsweb/decisionengine/basic/BasicDataProvider.java
+++ b/src/test/java/com/imsweb/decisionengine/basic/BasicDataProvider.java
@@ -21,7 +21,7 @@ import com.imsweb.staging.Staging;
 public class BasicDataProvider implements DataProvider {
 
     private static String _MATCH_ALL_STRING = "*";
-    private static BasicStringRange _MATCH_ALL_ENDPOINT = new BasicStringRange();
+    private static BasicRange _MATCH_ALL_ENDPOINT = new BasicRange();
     private Map<String, BasicTable> _tables = new HashMap<>();
     private Map<String, BasicDefinition> _definitions = new HashMap<>();
 
@@ -90,12 +90,12 @@ public class BasicDataProvider implements DataProvider {
                     switch (col.getType()) {
                         case INPUT:
                             // if there are no ranges in the list, that means the cell was "blank" and is not needed in the table row
-                            List<BasicStringRange> ranges = splitValues(cellValue);
+                            List<BasicRange> ranges = splitValues(cellValue);
                             if (!ranges.isEmpty()) {
                                 tableRowEntity.addInput(col.getKey(), ranges);
 
                                 // if there are key references used (values that reference other inputs) like {{key}}, then add them to the extra inputs list
-                                for (BasicStringRange range : ranges) {
+                                for (BasicRange range : ranges) {
                                     if (DecisionEngine.isReferenceVariable(range.getLow()))
                                         extraInputs.add(DecisionEngine.trimBraces(range.getLow()));
                                     if (DecisionEngine.isReferenceVariable(range.getHigh()))
@@ -165,7 +165,7 @@ public class BasicDataProvider implements DataProvider {
     }
 
     /**
-     * Parses a string of values into a List of StringRange entities.  The values can contain ranges and multiple values.  Some examples might be:
+     * Parses a string of values into a List of Range entities.  The values can contain ranges and multiple values.  Some examples might be:
      * <p>
      * 10
      * 10-14
@@ -174,10 +174,10 @@ public class BasicDataProvider implements DataProvider {
      * </p>
      * Note that all values (both low and high) must be the same length since they are evaluated using String comparison.
      * @param values a string of values
-     * @return a List of BasicStringRange objects
+     * @return a List of BasicRange objects
      */
-    protected List<BasicStringRange> splitValues(String values) {
-        List<BasicStringRange> convertedRanges = new ArrayList<>();
+    protected List<BasicRange> splitValues(String values) {
+        List<BasicRange> convertedRanges = new ArrayList<>();
 
         if (values != null) {
             // if the value of the string is "*", then consider it as matching anything
@@ -194,15 +194,15 @@ public class BasicDataProvider implements DataProvider {
                     // may need to revisit this issue later.
                     String[] parts = range.split("-");
                     if (parts.length == 1)
-                        convertedRanges.add(new BasicStringRange(parts[0].trim(), parts[0].trim()));
+                        convertedRanges.add(new BasicRange(parts[0].trim(), parts[0].trim()));
                     else if (parts.length == 2) {
                         if (parts[0].trim().length() != parts[1].trim().length())
-                            convertedRanges.add(new BasicStringRange(range.trim(), range.trim()));
+                            convertedRanges.add(new BasicRange(range.trim(), range.trim()));
                         else
-                            convertedRanges.add(new BasicStringRange(parts[0].trim(), parts[1].trim()));
+                            convertedRanges.add(new BasicRange(parts[0].trim(), parts[1].trim()));
                     }
                     else
-                        convertedRanges.add(new BasicStringRange(range.trim(), range.trim()));
+                        convertedRanges.add(new BasicRange(range.trim(), range.trim()));
                 }
             }
         }

--- a/src/test/java/com/imsweb/decisionengine/basic/BasicRange.java
+++ b/src/test/java/com/imsweb/decisionengine/basic/BasicRange.java
@@ -6,9 +6,9 @@ package com.imsweb.decisionengine.basic;
 import java.util.Map;
 
 import com.imsweb.decisionengine.DecisionEngine;
-import com.imsweb.decisionengine.StringRange;
+import com.imsweb.decisionengine.Range;
 
-public class BasicStringRange extends StringRange {
+public class BasicRange extends Range {
 
     private String _low;
     private String _high;
@@ -17,16 +17,16 @@ public class BasicStringRange extends StringRange {
     /**
      * Construct a BasicString range that matches any string
      */
-    public BasicStringRange() {
+    public BasicRange() {
         _usesContext = false;
     }
 
     /**
-     * Construct a BasicStringRange with a low and high bound
+     * Construct a BasicRange with a low and high bound
      * @param low low value
      * @param high high value
      */
-    public BasicStringRange(String low, String high) {
+    public BasicRange(String low, String high) {
         if (low == null || high == null)
             throw new IllegalStateException("Invalid range");
         if (low.length() != high.length())

--- a/src/test/java/com/imsweb/decisionengine/basic/BasicTableRow.java
+++ b/src/test/java/com/imsweb/decisionengine/basic/BasicTableRow.java
@@ -12,29 +12,29 @@ import com.imsweb.decisionengine.TableRow;
 
 public class BasicTableRow implements TableRow {
 
-    private Map<String, List<BasicStringRange>> _inputs = new HashMap<>();
+    private Map<String, List<BasicRange>> _inputs = new HashMap<>();
     private String _description;
     private List<BasicEndpoint> _endpoints = new ArrayList<>();
 
     @Override
-    public List<BasicStringRange> getColumnInput(String key) {
+    public List<BasicRange> getColumnInput(String key) {
         return _inputs.get(key);
     }
 
-    public Map<String, List<BasicStringRange>> getInputs() {
+    public Map<String, List<BasicRange>> getInputs() {
         return _inputs;
     }
 
-    public void setInputs(Map<String, List<BasicStringRange>> inputs) {
+    public void setInputs(Map<String, List<BasicRange>> inputs) {
         _inputs = inputs;
     }
 
     /**
      * Add a single columns input list
      * @param key an input key
-     * @param range a List of BasicStringRange objects
+     * @param range a List of BasicRange objects
      */
-    public void addInput(String key, List<BasicStringRange> range) {
+    public void addInput(String key, List<BasicRange> range) {
         _inputs.put(key, range);
     }
 

--- a/src/test/java/com/imsweb/staging/StagingDataProviderTest.java
+++ b/src/test/java/com/imsweb/staging/StagingDataProviderTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 
 import com.imsweb.decisionengine.ColumnDefinition.ColumnType;
 import com.imsweb.staging.entities.StagingColumnDefinition;
-import com.imsweb.staging.entities.StagingStringRange;
+import com.imsweb.staging.entities.StagingRange;
 import com.imsweb.staging.entities.StagingTable;
 
 import static org.junit.Assert.assertEquals;
@@ -68,7 +68,7 @@ public class StagingDataProviderTest {
 
         assertEquals(10, StagingDataProvider.splitValues("A,B,C,D,E,F,G,H,I,J").size());
 
-        List<StagingStringRange> ranges = StagingDataProvider.splitValues(",1,2,3,4");
+        List<StagingRange> ranges = StagingDataProvider.splitValues(",1,2,3,4");
         assertEquals(5, ranges.size());
         assertEquals("", ranges.get(0).getLow());
         assertEquals("", ranges.get(0).getHigh());

--- a/src/test/java/com/imsweb/staging/StagingRangeTest.java
+++ b/src/test/java/com/imsweb/staging/StagingRangeTest.java
@@ -5,29 +5,29 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import com.imsweb.staging.entities.StagingStringRange;
+import com.imsweb.staging.entities.StagingRange;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class StagingStringRangeTest {
+public class StagingRangeTest {
 
     @Test
     public void testRanges() {
-        assertFalse(new StagingStringRange("100", "103").contains("099", new HashMap<>()));
-        assertTrue(new StagingStringRange("100", "103").contains("100", new HashMap<>()));
-        assertTrue(new StagingStringRange("100", "103").contains("102", new HashMap<>()));
-        assertTrue(new StagingStringRange("100", "103").contains("103", new HashMap<>()));
-        assertFalse(new StagingStringRange("100", "103").contains("104", new HashMap<>()));
+        assertFalse(new StagingRange("100", "103").contains("099", new HashMap<>()));
+        assertTrue(new StagingRange("100", "103").contains("100", new HashMap<>()));
+        assertTrue(new StagingRange("100", "103").contains("102", new HashMap<>()));
+        assertTrue(new StagingRange("100", "103").contains("103", new HashMap<>()));
+        assertFalse(new StagingRange("100", "103").contains("104", new HashMap<>()));
 
         // test that if the value is a shorter length it is not found to be a match
-        assertFalse(new StagingStringRange("020500", "999999").contains("1", new HashMap<>()));
+        assertFalse(new StagingRange("020500", "999999").contains("1", new HashMap<>()));
     }
 
     @Test
     public void testContext() {
         Map<String, String> context = new HashMap<>();
-        StagingStringRange range = new StagingStringRange("2000", "{{current_year}}");
+        StagingRange range = new StagingRange("2000", "{{current_year}}");
 
         assertFalse(range.contains("2004", context));
 
@@ -52,27 +52,27 @@ public class StagingStringRangeTest {
 
     @Test(expected = IllegalStateException.class)
     public void testNull() {
-        assertFalse(new StagingStringRange(null, null).contains("099", new HashMap<>()));
+        assertFalse(new StagingRange(null, null).contains("099", new HashMap<>()));
     }
 
     @Test
     public void testEmptyBothValues() {
-        assertFalse(new StagingStringRange("", "").contains("099", new HashMap<>()));
+        assertFalse(new StagingRange("", "").contains("099", new HashMap<>()));
     }
 
     @Test
     public void testEmptyOneValues() {
-        assertFalse(new StagingStringRange("999", "").contains("999", new HashMap<>()));
-        assertFalse(new StagingStringRange("", "999").contains("999", new HashMap<>()));
+        assertFalse(new StagingRange("999", "").contains("999", new HashMap<>()));
+        assertFalse(new StagingRange("", "999").contains("999", new HashMap<>()));
     }
 
     @Test
     public void testDifferentLength() {
-        assertFalse(new StagingStringRange("99", "999").contains("099", new HashMap<>()));
-        assertFalse(new StagingStringRange("999", "99").contains("099", new HashMap<>()));
+        assertFalse(new StagingRange("AA", "AAA").contains("AAA", new HashMap<>()));
+        assertFalse(new StagingRange("BBB", "BB").contains("BBB", new HashMap<>()));
 
-        assertFalse(new StagingStringRange("999", "99").contains("99", new HashMap<>()));
-        assertFalse(new StagingStringRange("99", "999").contains("99", new HashMap<>()));
+        assertFalse(new StagingRange("CCC", "CC").contains("CC", new HashMap<>()));
+        assertFalse(new StagingRange("DD", "DDD").contains("DD", new HashMap<>()));
 
     }
 }

--- a/src/test/java/com/imsweb/staging/StagingRangeTest.java
+++ b/src/test/java/com/imsweb/staging/StagingRangeTest.java
@@ -68,11 +68,28 @@ public class StagingRangeTest {
 
     @Test
     public void testDifferentLength() {
+        // string ranges must be the same length
         assertFalse(new StagingRange("AA", "AAA").contains("AAA", new HashMap<>()));
         assertFalse(new StagingRange("BBB", "BB").contains("BBB", new HashMap<>()));
-
         assertFalse(new StagingRange("CCC", "CC").contains("CC", new HashMap<>()));
         assertFalse(new StagingRange("DD", "DDD").contains("DD", new HashMap<>()));
 
+        // numeric ranges do not have to be the same length
+        assertTrue(new StagingRange("99", "999").contains("150", new HashMap<>()));
+        assertFalse(new StagingRange("999", "99").contains("150", new HashMap<>()));
+    }
+
+    @Test
+    public void testNumericRanges() {
+        assertFalse(new StagingRange("0.1", "99999.9").contains("0.0", new HashMap<>()));
+        assertFalse(new StagingRange("0.1", "99999.9").contains("100000", new HashMap<>()));
+        assertFalse(new StagingRange("0.1", "99999.9").contains("100000.1", new HashMap<>()));
+
+        assertTrue(new StagingRange("0.1", "99999.9").contains("0.1", new HashMap<>()));
+        assertTrue(new StagingRange("0.1", "99999.9").contains("500.1", new HashMap<>()));
+        assertTrue(new StagingRange("0.1", "99999.9").contains("99999.9", new HashMap<>()));
+
+        // nothing checks that a decimal is there.  Non-decimal value will still be considered in the range.
+        assertTrue(new StagingRange("0.1", "99999.9").contains("1000", new HashMap<>()));
     }
 }

--- a/src/test/java/com/imsweb/staging/StagingRangeTest.java
+++ b/src/test/java/com/imsweb/staging/StagingRangeTest.java
@@ -92,4 +92,17 @@ public class StagingRangeTest {
         // nothing checks that a decimal is there.  Non-decimal value will still be considered in the range.
         assertTrue(new StagingRange("0.1", "99999.9").contains("1000", new HashMap<>()));
     }
+
+    @Test
+    public void testIsNumeric() {
+        assertTrue(StagingRange.isNumeric("0"));
+        assertTrue(StagingRange.isNumeric("1"));
+        assertTrue(StagingRange.isNumeric("-1"));
+        assertTrue(StagingRange.isNumeric("1.1"));
+
+        assertFalse(StagingRange.isNumeric(null));
+        assertFalse(StagingRange.isNumeric(""));
+        assertFalse(StagingRange.isNumeric("1.1.1"));
+        assertFalse(StagingRange.isNumeric("NAN"));
+    }
 }

--- a/src/test/java/com/imsweb/staging/StagingTest.java
+++ b/src/test/java/com/imsweb/staging/StagingTest.java
@@ -19,9 +19,9 @@ import org.junit.Test;
 import com.imsweb.decisionengine.ColumnDefinition;
 import com.imsweb.staging.entities.StagingColumnDefinition;
 import com.imsweb.staging.entities.StagingMapping;
+import com.imsweb.staging.entities.StagingRange;
 import com.imsweb.staging.entities.StagingSchema;
 import com.imsweb.staging.entities.StagingSchemaInput;
-import com.imsweb.staging.entities.StagingStringRange;
 import com.imsweb.staging.entities.StagingTable;
 import com.imsweb.staging.entities.StagingTableRow;
 import com.imsweb.staging.tnm.TnmDataProvider;
@@ -252,9 +252,9 @@ public abstract class StagingTest {
 
         // loop over each row
         for (StagingTableRow row : table.getTableRows()) {
-            List<StagingStringRange> ranges = row.getInputs().get(key);
+            List<StagingRange> ranges = row.getInputs().get(key);
 
-            for (StagingStringRange range : ranges) {
+            for (StagingRange range : ranges) {
                 String low = range.getLow();
                 String high = range.getHigh();
 

--- a/src/test/java/com/imsweb/staging/cs/CsStagingTest.java
+++ b/src/test/java/com/imsweb/staging/cs/CsStagingTest.java
@@ -31,9 +31,9 @@ import com.imsweb.staging.StagingTest;
 import com.imsweb.staging.cs.CsDataProvider.CsVersion;
 import com.imsweb.staging.cs.CsStagingData.CsOutput;
 import com.imsweb.staging.cs.CsStagingData.CsStagingInputBuilder;
+import com.imsweb.staging.entities.StagingRange;
 import com.imsweb.staging.entities.StagingSchema;
 import com.imsweb.staging.entities.StagingSchemaInput;
-import com.imsweb.staging.entities.StagingStringRange;
 import com.imsweb.staging.entities.StagingTable;
 import com.imsweb.staging.entities.StagingTableRow;
 
@@ -784,7 +784,7 @@ public class CsStagingTest extends StagingTest {
                 // loop over each row
                 for (StagingTableRow row : table.getTableRows()) {
                     // loop over all input cells
-                    for (Map.Entry<String, List<StagingStringRange>> entry : row.getInputs().entrySet()) {
+                    for (Map.Entry<String, List<StagingRange>> entry : row.getInputs().entrySet()) {
                         String key = entry.getKey();
 
                         // only validate keys that are actually INPUT values
@@ -799,7 +799,7 @@ public class CsStagingTest extends StagingTest {
                         Integer expectedFieldLength = inputTableLengths.get(validationTableId);
 
                         // loop over list of ranges
-                        for (StagingStringRange range : entry.getValue()) {
+                        for (StagingRange range : entry.getValue()) {
                             String low = range.getLow();
                             String high = range.getHigh();
 


### PR DESCRIPTION
Prior to this change, the ranges supported buy the algorithms has the requirement that each side was the same length.  That is because we were using `String` comparisons.  With upcoming algorithms there is a requirement to support numeric ranges.  For example,

```
"0.1-99999.9"
```

The solution is that for numeric ranges we will compare as float values (even if integer):

- If the low and high values ranges are different and are both "numeric", then the value will be compared after converting to a `Float` (which will work for the `Integer` type fields as well).
- Otherwise it will be compared as a `String` but the strings must be the same length otherwise consider different