### PR TITLE
Fix for numeric ranges not being correctly parsed to ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Download [the latest JAR][1] or grab via Maven:
 <dependency>
     <groupId>com.imsweb</groupId>
     <artifactId>staging-client-java</artifactId>
-    <version>2.13</version>
+    <version>2.14</version>
 </dependency>
 ```
 
 or via Gradle:
 
 ```groovy
-compile 'com.imsweb.com:staging-client-java:2.13'
+compile 'com.imsweb.com:staging-client-java:2.14'
 ```
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'com.imsweb'
-version = '2.13'
+version = '2.14'
 description = 'Java client library for staging calculations'
 
 println "Starting build using ${Jvm.current()}"

--- a/src/main/java/com/imsweb/staging/StagingDataProvider.java
+++ b/src/main/java/com/imsweb/staging/StagingDataProvider.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
@@ -44,7 +45,9 @@ public abstract class StagingDataProvider implements DataProvider {
     // tables that all algorithm versions must have
     public static final String PRIMARY_SITE_TABLE = "primary_site";
     public static final String HISTOLOGY_TABLE = "histology";
-
+    private static final Pattern _COLON = Pattern.compile(":");
+    private static final Pattern _COMMA = Pattern.compile(",");
+    private static final Pattern _DASH = Pattern.compile("-");
     // output all dates in ISO-8061 format and UTC time
     private static final DateFormat _DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 
@@ -201,7 +204,7 @@ public abstract class StagingDataProvider implements DataProvider {
      * @return an Endpoint object
      */
     public static StagingEndpoint parseEndpoint(String endpoint) {
-        String[] parts = endpoint.split(":", 2);
+        String[] parts = _COLON.split(endpoint, 2);
 
         EndpointType type = null;
 
@@ -239,7 +242,7 @@ public abstract class StagingDataProvider implements DataProvider {
                 convertedRanges.add(_MATCH_ALL_ENDPOINT);
             else {
                 // split the string; the "-1" makes sure to not discard empty strings
-                String[] ranges = values.split(",", -1);
+                String[] ranges = _COMMA.split(values, -1);
 
                 for (String range : ranges) {
                     // Not sure if this is the best way to handle this, but I ran into a problem when I converted the CS data.  One of the tables had
@@ -247,7 +250,7 @@ public abstract class StagingDataProvider implements DataProvider {
                     // The only thing I can think of is for cases like this, assume it is not a range and use the whole string as a non-range value.
                     // The problem is that if something is entered incorrectly and was supposed to be a range, we will not process it correctly.  We
                     // may need to revisit this issue later.
-                    String[] parts = range.split("-");
+                    String[] parts = _DASH.split(range);
                     if (parts.length == 2) {
                         String low = parts[0].trim();
                         String high = parts[1].trim();

--- a/src/main/java/com/imsweb/staging/StagingDataProvider.java
+++ b/src/main/java/com/imsweb/staging/StagingDataProvider.java
@@ -249,11 +249,18 @@ public abstract class StagingDataProvider implements DataProvider {
                     // may need to revisit this issue later.
                     String[] parts = range.split("-");
                     if (parts.length == 2) {
-                        // don't worry about length differences if one of the parts is a context variable
-                        if (parts[0].trim().length() != parts[1].trim().length() && !DecisionEngine.isReferenceVariable(parts[0].trim()) && !DecisionEngine.isReferenceVariable(parts[1].trim()))
-                            convertedRanges.add(new StagingRange(range.trim(), range.trim()));
+                        String low = parts[0].trim();
+                        String high = parts[1].trim();
+
+                        // check if both sides of the range are numeric values; if so the length does not have to match
+                        boolean isNumericRange = StagingRange.isNumeric(low) && StagingRange.isNumeric(high);
+
+                        // if same length, a numeric range, or one of the parts is a context variable, use the low and high as range.  Otherwise consier
+                        // a single value (i.e. low = high)
+                        if (low.length() == high.length() || isNumericRange || DecisionEngine.isReferenceVariable(low) || DecisionEngine.isReferenceVariable(high))
+                            convertedRanges.add(new StagingRange(low, high));
                         else
-                            convertedRanges.add(new StagingRange(parts[0].trim(), parts[1].trim()));
+                            convertedRanges.add(new StagingRange(range.trim(), range.trim()));
                     }
                     else
                         convertedRanges.add(new StagingRange(range.trim(), range.trim()));

--- a/src/main/java/com/imsweb/staging/StagingDataProvider.java
+++ b/src/main/java/com/imsweb/staging/StagingDataProvider.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
@@ -45,9 +44,7 @@ public abstract class StagingDataProvider implements DataProvider {
     // tables that all algorithm versions must have
     public static final String PRIMARY_SITE_TABLE = "primary_site";
     public static final String HISTOLOGY_TABLE = "histology";
-    private static final Pattern _COLON = Pattern.compile(":");
-    private static final Pattern _COMMA = Pattern.compile(",");
-    private static final Pattern _DASH = Pattern.compile("-");
+
     // output all dates in ISO-8061 format and UTC time
     private static final DateFormat _DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 
@@ -204,7 +201,7 @@ public abstract class StagingDataProvider implements DataProvider {
      * @return an Endpoint object
      */
     public static StagingEndpoint parseEndpoint(String endpoint) {
-        String[] parts = _COLON.split(endpoint, 2);
+        String[] parts = endpoint.split(":", 2);
 
         EndpointType type = null;
 
@@ -242,7 +239,7 @@ public abstract class StagingDataProvider implements DataProvider {
                 convertedRanges.add(_MATCH_ALL_ENDPOINT);
             else {
                 // split the string; the "-1" makes sure to not discard empty strings
-                String[] ranges = _COMMA.split(values, -1);
+                String[] ranges = values.split(",", -1);
 
                 for (String range : ranges) {
                     // Not sure if this is the best way to handle this, but I ran into a problem when I converted the CS data.  One of the tables had
@@ -250,7 +247,7 @@ public abstract class StagingDataProvider implements DataProvider {
                     // The only thing I can think of is for cases like this, assume it is not a range and use the whole string as a non-range value.
                     // The problem is that if something is entered incorrectly and was supposed to be a range, we will not process it correctly.  We
                     // may need to revisit this issue later.
-                    String[] parts = _DASH.split(range);
+                    String[] parts = range.split("-");
                     if (parts.length == 2) {
                         String low = parts[0].trim();
                         String high = parts[1].trim();

--- a/src/test/java/com/imsweb/staging/StagingDataProviderTest.java
+++ b/src/test/java/com/imsweb/staging/StagingDataProviderTest.java
@@ -116,15 +116,16 @@ public class StagingDataProviderTest {
         assertEquals("N0(mol-)", ranges.get(0).getLow());
         assertEquals("N0(mol-)", ranges.get(0).getHigh());
 
+        // test numeric ranges
         ranges = StagingDataProvider.splitValues("1-21");
         assertEquals(1, ranges.size());
-        assertEquals("1-21", ranges.get(0).getLow());
-        assertEquals("1-21", ranges.get(0).getHigh());
+        assertEquals("1", ranges.get(0).getLow());
+        assertEquals("21", ranges.get(0).getHigh());
 
         ranges = StagingDataProvider.splitValues("21-111");
         assertEquals(1, ranges.size());
-        assertEquals("21-111", ranges.get(0).getLow());
-        assertEquals("21-111", ranges.get(0).getHigh());
+        assertEquals("21", ranges.get(0).getLow());
+        assertEquals("111", ranges.get(0).getHigh());
     }
 
     @Test


### PR DESCRIPTION
The support for numeric ranges was not working properly.  When the raw table rows were processed it was still requiring ranges to have the same length on both sides.  The comparison was working but the initial parse was never creating ranges for the numeric ones.