### PR TITLE
EOD fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ Download [the latest JAR][1] or grab via Maven:
 <dependency>
     <groupId>com.imsweb</groupId>
     <artifactId>staging-client-java</artifactId>
-    <version>3.0</version>
+    <version>3.1</version>
 </dependency>
 ```
 
 or via Gradle:
 
 ```groovy
-compile 'com.imsweb.com:staging-client-java:3.0'
+compile 'com.imsweb.com:staging-client-java:3.1'
 ```
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'com.imsweb'
-version = '3.0'
+version = '3.1'
 description = 'Java client library for staging calculations'
 
 println "Starting build using ${Jvm.current()}"

--- a/src/main/java/com/imsweb/staging/eod/EodSchemaLookup.java
+++ b/src/main/java/com/imsweb/staging/eod/EodSchemaLookup.java
@@ -16,6 +16,7 @@ public class EodSchemaLookup extends SchemaLookup {
     private static final Set<String> _ALLOWED_KEYS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             EodStagingData.PRIMARY_SITE_KEY,
             EodStagingData.HISTOLOGY_KEY,
+            EodInput.SEX.toString(),
             EodInput.DISCRIMINATOR_1.toString(),
             EodInput.DISCRIMINATOR_2.toString())));
 

--- a/src/main/java/com/imsweb/staging/eod/EodStagingData.java
+++ b/src/main/java/com/imsweb/staging/eod/EodStagingData.java
@@ -81,6 +81,8 @@ public class EodStagingData extends StagingData {
         PRIMARY_SITE("site"),
         HISTOLOGY("hist"),
         BEHAVIOR("behavior"),
+        SEX("sex"),
+        AGE_AT_DX("age_dx"),
         DISCRIMINATOR_1("discriminator_1"),
         DISCRIMINATOR_2("discriminator_2"),
         NODES_POS("nodes_pos"),

--- a/src/test/java/com/imsweb/staging/eod/EodStagingTest.java
+++ b/src/test/java/com/imsweb/staging/eod/EodStagingTest.java
@@ -160,6 +160,18 @@ public class EodStagingTest extends StagingTest {
     }
 
     @Test
+    public void testDiscriminatorInputs() {
+        Set<String> discriminators = new HashSet<>();
+        _STAGING.getSchemaIds().stream()
+                .map(schemaId -> _STAGING.getSchema(schemaId))
+                .filter(schema -> schema.getSchemaDiscriminators() != null)
+                .map(StagingSchema::getSchemaDiscriminators)
+                .forEach(discriminators::addAll);
+
+        assertEquals(new HashSet<>(Arrays.asList("sex", "discriminator_1", "discriminator_2")), discriminators);
+    }
+
+    @Test
     public void testLookupCache() {
         // do the same lookup twice
         List<StagingSchema> lookup = _STAGING.lookupSchema(new EodSchemaLookup("C629", "9231"));

--- a/src/test/java/com/imsweb/staging/eod/EodStagingTest.java
+++ b/src/test/java/com/imsweb/staging/eod/EodStagingTest.java
@@ -148,6 +148,15 @@ public class EodStagingTest extends StagingTest {
         schemaLookup.setInput(EodInput.DISCRIMINATOR_1.toString(), "1");
         lookup = _STAGING.lookupSchema(schemaLookup);
         assertEquals(0, lookup.size());
+
+        // test lookups based on sex
+        schemaLookup = new EodSchemaLookup("C481", "8720");
+        lookup = _STAGING.lookupSchema(schemaLookup);
+        assertEquals(2, lookup.size());
+        schemaLookup.setInput(EodInput.SEX.toString(), "1");
+        lookup = _STAGING.lookupSchema(schemaLookup);
+        assertEquals(1, lookup.size());
+        assertEquals("retroperitoneum", lookup.get(0).getId());
     }
 
     @Test


### PR DESCRIPTION
The `sex` discriminator was not include in the `EodSchemaLookup` entity.  It is required for certain schemas.  A unit test was also added to verify that all discriminators are now included.