### PR TITLE
Fix context cleanup (#43)

### DIFF
--- a/src/main/java/com/imsweb/staging/Staging.java
+++ b/src/main/java/com/imsweb/staging/Staging.java
@@ -249,12 +249,8 @@ public final class Staging {
      * @return a Set of schema identifiers
      */
     public Set<String> getInvolvedSchemas(String tableId) {
-        Set<String> schemas = new HashSet<>();
-
         // loop over all schemas and find the ones that have the passed table identifier in the involved table set
-        schemas.addAll(getSchemaIds().stream().filter(schemaId -> getInvolvedTables(schemaId).contains(tableId)).collect(Collectors.toList()));
-
-        return schemas;
+        return getSchemaIds().stream().filter(schemaId -> getInvolvedTables(schemaId).contains(tableId)).collect(Collectors.toSet());
     }
 
     /**
@@ -546,9 +542,8 @@ public final class Staging {
     /**
      * Add the context keys which are used in staging and other calls
      * @param context Map of context
-     * @return updated Map of context
      */
-    private Map<String, String> addContextKeys(Map<String, String> context) {
+    private void addContextKeys(Map<String, String> context) {
         // make the algorithm version available in the context
         context.put(CTX_ALGORITHM_VERSION, getVersion());
 
@@ -556,17 +551,15 @@ public final class Staging {
         Calendar now = Calendar.getInstance();
         context.put(CTX_YEAR_CURRENT, String.valueOf(now.get(Calendar.YEAR)));
 
-        return context;
     }
 
     /**
      * Remove all context keys
      * @param context Map of context
-     * @return updated Map of context
      */
-    private Map<String, String> removeContextKeys(Map<String, String> context) {
+    private void removeContextKeys(Map<String, String> context) {
+        context.remove(CTX_ALGORITHM_VERSION);
         context.remove(CTX_YEAR_CURRENT);
 
-        return context;
     }
 }

--- a/src/test/java/com/imsweb/staging/eod/EodStagingTest.java
+++ b/src/test/java/com/imsweb/staging/eod/EodStagingTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import com.imsweb.staging.SchemaLookup;
 import com.imsweb.staging.Staging;
 import com.imsweb.staging.StagingData;
+import com.imsweb.staging.StagingData.Result;
 import com.imsweb.staging.StagingFileDataProvider;
 import com.imsweb.staging.StagingTest;
 import com.imsweb.staging.entities.StagingSchema;
@@ -383,6 +384,48 @@ public class EodStagingTest extends StagingTest {
         // converting to other encoding should change the text
         assertNotEquals(table.getNotes(), new String(table.getNotes().getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.ISO_8859_1));
         assertNotEquals(table.getNotes(), new String(table.getNotes().getBytes(StandardCharsets.US_ASCII), StandardCharsets.US_ASCII));
+    }
+
+    @Test
+    public void testContentNotReturnedForInvalidInput() {
+        EodStagingData data = new EodStagingInputBuilder()
+                .withInput(EodInput.PRIMARY_SITE, "C713")
+                .withInput(EodInput.HISTOLOGY, "8020")
+                .withInput(EodInput.BEHAVIOR, "3")
+                .withInput(EodInput.DX_YEAR, "2018")
+                .withInput(EodInput.EOD_PRIMARY_TUMOR, "200")
+                .withInput(EodInput.EOD_REGIONAL_NODES, "300")
+                .withInput(EodInput.EOD_METS, "00").build();
+
+        // perform the staging
+        _STAGING.stage(data);
+
+        assertEquals(Result.FAILED_INVALID_INPUT, data.getResult());
+        assertEquals("brain", data.getSchemaId());
+        assertEquals(2, data.getErrors().size());
+        assertEquals(0, data.getPath().size());
+        assertEquals(0, data.getOutput().size());
+    }
+
+    @Test
+    public void testContentNotReturnedForInvalidYear() {
+        EodStagingData data = new EodStagingInputBuilder()
+                .withInput(EodInput.PRIMARY_SITE, "C713")
+                .withInput(EodInput.HISTOLOGY, "8020")
+                .withInput(EodInput.BEHAVIOR, "3")
+                .withInput(EodInput.DX_YEAR, "2010")
+                .withInput(EodInput.EOD_PRIMARY_TUMOR, "200")
+                .withInput(EodInput.EOD_REGIONAL_NODES, "300")
+                .withInput(EodInput.EOD_METS, "00").build();
+
+        // perform the staging
+        _STAGING.stage(data);
+
+        assertEquals(Result.FAILED_INVALID_YEAR_DX, data.getResult());
+        assertEquals("brain", data.getSchemaId());
+        assertEquals(0, data.getErrors().size());
+        assertEquals(0, data.getPath().size());
+        assertEquals(0, data.getOutput().size());
     }
 
 }


### PR DESCRIPTION
The `CTX_ALGORITHM_VERSION` context key was not being removed after staging.