### PR TITLE
Output when on_invalid_input = FAIL_WHEN_USED_FOR_STAGING (#45)

### DIFF
--- a/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
+++ b/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
@@ -593,6 +593,10 @@ public class DecisionEngine {
             if (entry.getValue() != null)
                 context.put(entry.getKey(), entry.getValue().trim());
 
+        // add all output keys to the context; if no default is supplied, use an empty string
+        for (Entry<String, ? extends Output> entry : definition.getOutputMap().entrySet())
+            context.put(entry.getValue().getKey(), entry.getValue().getDefault() != null ? translateValue(entry.getValue().getDefault(), context) : "");
+
         // validate inputs
         boolean stopForBadInput = false;
         for (String key : definition.getInputMap().keySet()) {
@@ -627,7 +631,6 @@ public class DecisionEngine {
                         stopForBadInput = true;
                 }
             }
-
         }
 
         // if an invalid input was flagged to stop processing, set result and exit
@@ -635,10 +638,6 @@ public class DecisionEngine {
             result.setType(Result.Type.FAILED_INPUT);
             return result;
         }
-
-        // add all output keys to the context; if no default is supplied, use an empty string
-        for (Entry<String, ? extends Output> entry : definition.getOutputMap().entrySet())
-            context.put(entry.getValue().getKey(), entry.getValue().getDefault() != null ? translateValue(entry.getValue().getDefault(), context) : "");
 
         // add the initial context
         if (definition.getInitialContext() != null)

--- a/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
+++ b/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
@@ -593,10 +593,6 @@ public class DecisionEngine {
             if (entry.getValue() != null)
                 context.put(entry.getKey(), entry.getValue().trim());
 
-        // add all output keys to the context; if no default is supplied, use an empty string
-        for (Entry<String, ? extends Output> entry : definition.getOutputMap().entrySet())
-            context.put(entry.getValue().getKey(), entry.getValue().getDefault() != null ? translateValue(entry.getValue().getDefault(), context) : "");
-
         // validate inputs
         boolean stopForBadInput = false;
         for (String key : definition.getInputMap().keySet()) {
@@ -631,18 +627,23 @@ public class DecisionEngine {
                         stopForBadInput = true;
                 }
             }
+
         }
+
+        // add all output keys to the context; if no default is supplied, use an empty string
+        for (Entry<String, ? extends Output> entry : definition.getOutputMap().entrySet())
+            context.put(entry.getValue().getKey(), entry.getValue().getDefault() != null ? translateValue(entry.getValue().getDefault(), context) : "");
+
+        // add the initial context
+        if (definition.getInitialContext() != null)
+            for (KeyValue keyValue : definition.getInitialContext())
+                context.put(keyValue.getKey(), translateValue(keyValue.getValue(), context));
 
         // if an invalid input was flagged to stop processing, set result and exit
         if (stopForBadInput) {
             result.setType(Result.Type.FAILED_INPUT);
             return result;
         }
-
-        // add the initial context
-        if (definition.getInitialContext() != null)
-            for (KeyValue keyValue : definition.getInitialContext())
-                context.put(keyValue.getKey(), translateValue(keyValue.getValue(), context));
 
         // process each mapping if it is "involved", which is checked using the current context against inclusion/exclusion criteria
         if (definition.getMappings() != null) {

--- a/src/test/java/com/imsweb/staging/cs/CsStagingTest.java
+++ b/src/test/java/com/imsweb/staging/cs/CsStagingTest.java
@@ -831,4 +831,36 @@ public class CsStagingTest extends StagingTest {
 
         assertNoErrors(errors, "inputs values in tables which are not valid");
     }
+
+    @Test
+    public void testInvalidInputProducesOutput() {
+        CsStagingData data = new CsStagingData();
+        data.setInput(CsStagingData.CsInput.PRIMARY_SITE, "C680");
+        data.setInput(CsStagingData.CsInput.HISTOLOGY, "8000");
+        data.setInput(CsStagingData.CsInput.BEHAVIOR, "3");
+        data.setInput(CsStagingData.CsInput.GRADE, "9");
+        data.setInput(CsStagingData.CsInput.DX_YEAR, "2013");
+        data.setInput(CsStagingData.CsInput.CS_VERSION_ORIGINAL, "020550");
+        data.setInput(CsStagingData.CsInput.TUMOR_SIZE, "075");
+        data.setInput(CsStagingData.CsInput.EXTENSION, "100");
+        data.setInput(CsStagingData.CsInput.EXTENSION_EVAL, "9");
+        data.setInput(CsStagingData.CsInput.LYMPH_NODES, "100");
+        data.setInput(CsStagingData.CsInput.LYMPH_NODES_EVAL, "9");
+        data.setInput(CsStagingData.CsInput.REGIONAL_NODES_POSITIVE, "99");
+        data.setInput(CsStagingData.CsInput.REGIONAL_NODES_EXAMINED, "99");
+        data.setInput(CsStagingData.CsInput.METS_AT_DX, "20");  // this is an invalid value
+        data.setInput(CsStagingData.CsInput.METS_EVAL, "9");
+        data.setInput(CsStagingData.CsInput.LVI, "9");
+        data.setInput(CsStagingData.CsInput.AGE_AT_DX, "060");
+        data.setSsf(1, "020");
+
+        // perform the staging
+        _STAGING.stage(data);
+
+        assertEquals(Result.STAGED, data.getResult());
+        assertEquals("urethra", data.getSchemaId());
+        assertEquals(6, data.getErrors().size());
+        assertEquals(37, data.getPath().size());
+        assertEquals("129", data.getOutput(CsOutput.SCHEMA_NUMBER));
+    }
 }

--- a/src/test/java/com/imsweb/staging/eod/EodStagingTest.java
+++ b/src/test/java/com/imsweb/staging/eod/EodStagingTest.java
@@ -385,4 +385,9 @@ public class EodStagingTest extends StagingTest {
         assertNotEquals(table.getNotes(), new String(table.getNotes().getBytes(StandardCharsets.US_ASCII), StandardCharsets.US_ASCII));
     }
 
+    @Test
+    public void testBadInputsWithDefaultOutput() {
+
+    }
+
 }

--- a/src/test/java/com/imsweb/staging/eod/EodStagingTest.java
+++ b/src/test/java/com/imsweb/staging/eod/EodStagingTest.java
@@ -404,7 +404,11 @@ public class EodStagingTest extends StagingTest {
         assertEquals("brain", data.getSchemaId());
         assertEquals(2, data.getErrors().size());
         assertEquals(0, data.getPath().size());
-        assertEquals(0, data.getOutput().size());
+
+        // note that invalid input will still return the default outputs
+        assertEquals(8, data.getOutput().size());
+        assertEquals("XX", data.getOutput().get(EodOutput.AJCC_ID.toString()));
+        assertEquals("00721", data.getOutput().get(EodOutput.NAACCR_SCHEMA_ID.toString()));
     }
 
     @Test
@@ -425,6 +429,8 @@ public class EodStagingTest extends StagingTest {
         assertEquals("brain", data.getSchemaId());
         assertEquals(0, data.getErrors().size());
         assertEquals(0, data.getPath().size());
+
+        // invalid year of dx never gets into the engine process method so there is no default output set
         assertEquals(0, data.getOutput().size());
     }
 


### PR DESCRIPTION
If a schema has `on_invalid_input` set to FAIL_WHEN_USED_FOR_STAGING, then the output will always be empty when there is invalid required input.  This change still fails in the same way, but sets the `output` to whatever is defined with all their default values.