### PR TITLE
Add columns to errors

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Jul 05 10:53:06 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-all.zip

--- a/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
+++ b/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
@@ -785,7 +785,7 @@ public class DecisionEngine {
                     if (message == null || message.isEmpty())
                         message = "Matching resulted in an error in table '" + tableId + "' (" + getTableInputsAsString(table, result.getContext()) + ")";
 
-                    result.addError(new ErrorBuilder(Type.STAGING_ERROR).message(message).table(tableId).build());
+                    result.addError(new ErrorBuilder(Type.STAGING_ERROR).message(message).table(tableId).column(endpoint.getResultKey()).build());
                 }
                 else if (EndpointType.VALUE.equals(endpoint.getType())) {
                     // if output mapping(s) were provided, check whether the key was mapped

--- a/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
+++ b/src/main/java/com/imsweb/decisionengine/DecisionEngine.java
@@ -788,7 +788,7 @@ public class DecisionEngine {
                 else if (EndpointType.ERROR.equals(endpoint.getType())) {
                     String message = endpoint.getValue();
                     if (message == null || message.isEmpty())
-                        message = "Matching resulted in an error in table '" + tableId + "' (" + getTableInputsAsString(table, result.getContext()) + ")";
+                        message = "Matching resulted in an error in table '" + tableId + "' for column '" + endpoint.getResultKey() + "' (" + getTableInputsAsString(table, result.getContext()) + ")";
 
                     result.addError(new ErrorBuilder(Type.STAGING_ERROR).message(message).table(tableId).columns(Collections.singletonList(endpoint.getResultKey())).build());
                 }

--- a/src/main/java/com/imsweb/decisionengine/Error.java
+++ b/src/main/java/com/imsweb/decisionengine/Error.java
@@ -9,11 +9,12 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 /**
  * An error object
  */
-@JsonPropertyOrder({"type", "table", "key", "message"})
+@JsonPropertyOrder({"type", "table", "column", "key", "message"})
 public class Error {
 
     private Type _type;
     private String _table;
+    private String _column;
     private String _key;
     private String _message;
 
@@ -78,6 +79,15 @@ public class Error {
         _table = table;
     }
 
+    @JsonProperty("column")
+    public String getColumn() {
+        return _column;
+    }
+
+    public void setColumn(String column) {
+        _column = column;
+    }
+
     @JsonProperty("key")
     public String getKey() {
         return _key;
@@ -114,6 +124,11 @@ public class Error {
 
         public ErrorBuilder table(String table) {
             _error.setTable(table);
+            return this;
+        }
+
+        public ErrorBuilder column(String column) {
+            _error.setColumn(column);
             return this;
         }
 

--- a/src/main/java/com/imsweb/decisionengine/Error.java
+++ b/src/main/java/com/imsweb/decisionengine/Error.java
@@ -3,49 +3,22 @@
  */
 package com.imsweb.decisionengine;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * An error object
  */
-@JsonPropertyOrder({"type", "table", "column", "key", "message"})
+@JsonPropertyOrder({"type", "table", "columns", "key", "message"})
 public class Error {
 
     private Type _type;
     private String _table;
-    private String _column;
+    private List<String> _columns;
     private String _key;
     private String _message;
-
-    public enum Type {
-        // an input key was supplied that is not defined in the input definition
-        UNKNOWN_INPUT,
-
-        // a required input value was not contained in the input definition table
-        INVALID_REQUIRED_INPUT,
-
-        // a non-required input value was not contained in the input definition table
-        INVALID_NON_REQUIRED_INPUT,
-
-        // an input mapping from value did not exist
-        UNKNOWN_INPUT_MAPPING,
-
-        // an ERROR endpoint was hit during staging processing
-        STAGING_ERROR,
-
-        // a table was processed during staging and no match was found
-        MATCH_NOT_FOUND,
-
-        // a specified table does not exist
-        UNKNOWN_TABLE,
-
-        // processing a table ended up in an infinite loop due to JUMPs
-        INFINITE_LOOP,
-
-        // an output value was produced which was not contained in the output definition table
-        INVALID_OUTPUT
-    }
 
     /**
      * Default constructor
@@ -79,13 +52,13 @@ public class Error {
         _table = table;
     }
 
-    @JsonProperty("column")
-    public String getColumn() {
-        return _column;
+    @JsonProperty("columns")
+    public List<String> getColumns() {
+        return _columns;
     }
 
-    public void setColumn(String column) {
-        _column = column;
+    public void setColumns(List<String> columns) {
+        _columns = columns;
     }
 
     @JsonProperty("key")
@@ -104,6 +77,35 @@ public class Error {
 
     public void setMessage(String message) {
         _message = message;
+    }
+
+    public enum Type {
+        // an input key was supplied that is not defined in the input definition
+        UNKNOWN_INPUT,
+
+        // a required input value was not contained in the input definition table
+        INVALID_REQUIRED_INPUT,
+
+        // a non-required input value was not contained in the input definition table
+        INVALID_NON_REQUIRED_INPUT,
+
+        // an input mapping from value did not exist
+        UNKNOWN_INPUT_MAPPING,
+
+        // an ERROR endpoint was hit during staging processing
+        STAGING_ERROR,
+
+        // a table was processed during staging and no match was found
+        MATCH_NOT_FOUND,
+
+        // a specified table does not exist
+        UNKNOWN_TABLE,
+
+        // processing a table ended up in an infinite loop due to JUMPs
+        INFINITE_LOOP,
+
+        // an output value was produced which was not contained in the output definition table
+        INVALID_OUTPUT
     }
 
     /**
@@ -127,8 +129,8 @@ public class Error {
             return this;
         }
 
-        public ErrorBuilder column(String column) {
-            _error.setColumn(column);
+        public ErrorBuilder columns(List<String> columns) {
+            _error.setColumns(columns);
             return this;
         }
 

--- a/src/main/java/com/imsweb/staging/StagingDataProvider.java
+++ b/src/main/java/com/imsweb/staging/StagingDataProvider.java
@@ -178,8 +178,7 @@ public abstract class StagingDataProvider implements DataProvider {
                             break;
                         case ENDPOINT:
                             StagingEndpoint endpoint = parseEndpoint(cellValue);
-                            if (EndpointType.VALUE.equals(endpoint.getType()))
-                                endpoint.setResultKey(col.getKey());
+                            endpoint.setResultKey(col.getKey());
                             tableRowEntity.addEndpoint(endpoint);
 
                             // if there are key references used (values that reference other inputs) like {{key}}, then add them to the extra inputs list

--- a/src/test/java/com/imsweb/decisionengine/DecisionEngineTest.java
+++ b/src/test/java/com/imsweb/decisionengine/DecisionEngineTest.java
@@ -340,7 +340,7 @@ public class DecisionEngineTest {
         assertNull(DecisionEngine.matchTable(matchTable, input));
 
         input.put("size", "003");
-        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.JUMP, "some_crazy_table")), DecisionEngine.matchTable(matchTable, input));
+        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.JUMP, "some_crazy_table", "size_result")), DecisionEngine.matchTable(matchTable, input));
 
         input.put("size", "014");
         List<? extends Endpoint> results = DecisionEngine.matchTable(matchTable, input);
@@ -350,7 +350,7 @@ public class DecisionEngineTest {
         assertEquals("size_result", results.get(0).getResultKey());
 
         input.put("size", "086");
-        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.ERROR, "Get that huge stuff out of here!")), DecisionEngine.matchTable(matchTable, input));
+        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.ERROR, "Get that huge stuff out of here!", "size_result")), DecisionEngine.matchTable(matchTable, input));
 
         // try with a value not in the table
         input.put("size", "021");
@@ -429,23 +429,23 @@ public class DecisionEngineTest {
         assertNull(DecisionEngine.matchTable(matchTable, input));
 
         // specify to only match on key1, there should be a match to the first line
-        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.MATCH, "LINE1")),
+        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.MATCH, "LINE1", "result")),
                 DecisionEngine.matchTable(matchTable, input, new HashSet<>(Collections.singletonList("key1"))));
 
         // add key2 to the input map and there should be a match
         input.put("key2", "7");
-        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.MATCH, "LINE2")), DecisionEngine.matchTable(matchTable, input));
+        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.MATCH, "LINE2", "result")), DecisionEngine.matchTable(matchTable, input));
 
         // if searching on key1 only, even though key2 was supplied should still match to first line
-        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.MATCH, "LINE1")),
+        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.MATCH, "LINE1", "result")),
                 DecisionEngine.matchTable(matchTable, input, new HashSet<>(Collections.singletonList("key1"))));
 
         // supply an empty set of keys (the same meaning as not passing any keys
-        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.MATCH, "LINE1")), DecisionEngine.matchTable(matchTable, input, new HashSet<>()));
+        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.MATCH, "LINE1", "result")), DecisionEngine.matchTable(matchTable, input, new HashSet<>()));
 
         // supply an invalid key.  I think this should find nothing, but for the moment finds a match to the first row since none of the cells were compared to.  It
         // is the same as matching to a table with no INPUTS which would currently find a match to the first row.
-        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.MATCH, "LINE1")),
+        assertReflectionEquals(Collections.singletonList(new BasicEndpoint(EndpointType.MATCH, "LINE1", "result")),
                 DecisionEngine.matchTable(matchTable, input, new HashSet<>(Collections.singletonList("bad_key"))));
     }
 
@@ -823,6 +823,7 @@ public class DecisionEngineTest {
         assertEquals("999", result.getErrors().get(0).getMessage());
         assertNull(result.getErrors().get(0).getKey());
         assertEquals("table_sample_first", result.getErrors().get(0).getTable());
+        assertEquals("result", result.getErrors().get(0).getColumn());
     }
 
     @Test
@@ -1054,6 +1055,7 @@ public class DecisionEngineTest {
         assertEquals(1, result.getErrors().size());
         assertEquals(1, result.getPath().size());
         assertEquals("table_recursion", result.getErrors().get(0).getTable());
+        assertNull(result.getErrors().get(0).getColumn());
     }
 
     @Test
@@ -1080,6 +1082,8 @@ public class DecisionEngineTest {
         assertEquals(Type.STAGED, result.getType());
         assertTrue(result.hasErrors());
         assertEquals(1, result.getErrors().size());
+        assertEquals("table_multiple_inputs", result.getErrors().get(0).getTable());
+        assertEquals("r2", result.getErrors().get(0).getColumn());
         assertEquals("2_LINE2", result.getErrors().get(0).getMessage());
         assertEquals(1, result.getPath().size());
 

--- a/src/test/java/com/imsweb/decisionengine/DecisionEngineTest.java
+++ b/src/test/java/com/imsweb/decisionengine/DecisionEngineTest.java
@@ -78,6 +78,7 @@ public class DecisionEngineTest {
         table.addRawRow("0", "23-30", "Line3", "VALUE:LINE3");
         table.addRawRow("5", "20", "Line4", "JUMP:table_jump_sample");
         table.addRawRow("*", "55", "Line5", "VALUE:LINE5");
+        table.addRawRow("8", "99", "Line6", "ERROR:");
         table.addRawRow("9", "99", "Line6", "ERROR:999");
         provider.addTable(table);
 
@@ -469,12 +470,6 @@ public class DecisionEngineTest {
         assertEquals(EndpointType.VALUE, endpoints.get(0).getType());
         assertEquals("missing", endpoints.get(0).getValue());
 
-        //        input.put("a", " ");
-        //        endpoints = DecisionEngine.matchTable(tableMissing, input);
-        //        assertEquals(1, endpoints.size());
-        //        assertEquals(EndpointType.VALUE, endpoints.get(0).getType());
-        //        assertEquals("space", endpoints.get(0).getValue());
-
         input.put("a", "1");
         endpoints = DecisionEngine.matchTable(tableMissing, input);
         assertEquals(1, endpoints.size());
@@ -821,6 +816,18 @@ public class DecisionEngineTest {
         assertEquals(1, result.getErrors().size());
         assertEquals(2, result.getPath().size());
         assertEquals("999", result.getErrors().get(0).getMessage());
+        assertNull(result.getErrors().get(0).getKey());
+        assertEquals("table_sample_first", result.getErrors().get(0).getTable());
+        assertEquals(Collections.singletonList("result"), result.getErrors().get(0).getColumns());
+
+        // test case with generated error message (i.e. the column is "ERROR:" without a message
+        input.put("a", "8");
+        input.put("b", "99");
+        input.put("e", "X");
+        result = _ENGINE.process("starting_sample", input);
+        assertEquals(1, result.getErrors().size());
+        assertEquals(2, result.getPath().size());
+        assertEquals("Matching resulted in an error in table 'table_sample_first' for column 'result' (8,99)", result.getErrors().get(0).getMessage());
         assertNull(result.getErrors().get(0).getKey());
         assertEquals("table_sample_first", result.getErrors().get(0).getTable());
         assertEquals(Collections.singletonList("result"), result.getErrors().get(0).getColumns());

--- a/src/test/java/com/imsweb/decisionengine/basic/BasicDataProvider.java
+++ b/src/test/java/com/imsweb/decisionengine/basic/BasicDataProvider.java
@@ -105,8 +105,7 @@ public class BasicDataProvider implements DataProvider {
                             break;
                         case ENDPOINT:
                             BasicEndpoint endpoint = parseEndpoint(cellValue);
-                            if (EndpointType.VALUE.equals(endpoint.getType()))
-                                endpoint.setResultKey(col.getKey());
+                            endpoint.setResultKey(col.getKey());
                             tableRowEntity.addEndpoint(endpoint);
 
                             // if there are key references used (values that reference other inputs) like {{key}}, then add them to the extra inputs list

--- a/src/test/java/com/imsweb/decisionengine/basic/BasicEndpoint.java
+++ b/src/test/java/com/imsweb/decisionengine/basic/BasicEndpoint.java
@@ -18,13 +18,20 @@ public class BasicEndpoint implements Endpoint {
     }
 
     /**
-     * Construct with a type and value
-     * @param type a type
-     * @param value a value
+     * Constructor
      */
     public BasicEndpoint(EndpointType type, String value) {
         _type = type;
         _value = value;
+    }
+
+    /**
+     * Constructor
+     */
+    public BasicEndpoint(EndpointType type, String value, String resultKey) {
+        _type = type;
+        _value = value;
+        _resultKey = resultKey;
     }
 
     @Override


### PR DESCRIPTION
Closes #54 

This adds a new field to the `Error` class.

```java
List<String> _columns
```

It is set in two situations:

1. If there is a match to an `ERROR` cell, the list will contain a single element which represents the column property of the endpoint.
2. If there is no match found in any row (i.e. `MATCH_NOT_FOUND`), all the endpoint column properties will be added to the list.