### PR TITLE
Clean up dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.assertj:assertj-core:3.9.0'
     testImplementation 'org.unitils:unitils-core:3.4.6'
+    testImplementation 'org.mongodb.morphia:morphia:1.3.2'
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java'
+    id 'java-library'
     id 'checkstyle'
     id 'findbugs'
     id 'com.bmuschko.nexus' version '2.3.1'
@@ -23,19 +23,19 @@ repositories {
 }
 
 dependencies {
-    compile 'com.fasterxml.jackson.core:jackson-core:2.8.10'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.8.10'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.8.10'
+    api 'com.fasterxml.jackson.core:jackson-core:2.8.10'
+    api 'com.fasterxml.jackson.core:jackson-annotations:2.8.10'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.8.10'
 
     // morphia annotations are needed to make it easier to use in SEER*API
-    compile 'org.mongodb.morphia:morphia:1.3.2'
+    compileOnly 'org.mongodb.morphia:morphia:1.3.2'
 
-    compile 'com.github.ben-manes.caffeine:caffeine:2.6.2'
-    compile 'org.apache.commons:commons-lang3:3.7'
+    implementation 'com.github.ben-manes.caffeine:caffeine:2.6.2'
+    implementation 'org.apache.commons:commons-lang3:3.7'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.assertj:assertj-core:3.9.0'
-    testCompile 'org.unitils:unitils-core:3.4.6'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.assertj:assertj-core:3.9.0'
+    testImplementation 'org.unitils:unitils-core:3.4.6'
 }
 
 jar {


### PR DESCRIPTION
The staging entities have annotations that make them easier to use in SEER*API.  The library was exposing them and did not need to.  This removes them from external dependencies.