### PR TITLE
Switch caching implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ Download [the latest JAR][1] or grab via Maven:
 <dependency>
     <groupId>com.imsweb</groupId>
     <artifactId>staging-client-java</artifactId>
-    <version>4.3</version>
+    <version>4.4</version>
 </dependency>
 ```
 
 or via Gradle:
 
 ```groovy
-compile 'com.imsweb.com:staging-client-java:4.3'
+compile 'com.imsweb.com:staging-client-java:4.4'
 ```
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     // morphia annotations are needed to make it easier to use in SEER*API
     api 'org.mongodb.morphia:morphia:1.3.2'
 
-    implementation 'com.github.ben-manes.caffeine:caffeine:2.6.2'
+    implementation 'org.cache2k:cache2k-all:1.2.0.Final'
     implementation 'org.apache.commons:commons-lang3:3.7'
 
     testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ description = 'Java client library for staging calculations'
 tasks.withType(JavaCompile) {
     // UTF-8 for all compilation tasks
     options.encoding = 'UTF-8'
-    
+
     // set language level
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -34,7 +34,7 @@ dependencies {
     api 'com.fasterxml.jackson.core:jackson-annotations:2.8.10'
     api 'com.fasterxml.jackson.core:jackson-databind:2.8.10'
 
-    // morphia annotations are needed to make it easier to use in SEER*API
+    // morphia annotations to make it easier to use in SEER*API
     api 'org.mongodb.morphia:morphia:1.3.2'
 
     implementation 'org.cache2k:cache2k-all:1.2.0.Final'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.imsweb'
-version = '4.3'
+version = '4.4'
 description = 'Java client library for staging calculations'
 
 // UTF-8 for all compilation tasks

--- a/src/main/java/com/imsweb/staging/StagingDataProvider.java
+++ b/src/main/java/com/imsweb/staging/StagingDataProvider.java
@@ -308,9 +308,8 @@ public abstract class StagingDataProvider implements DataProvider {
      * Clear the caches
      */
     public void invalidateCache() {
-        // TODO not sure how to do this?
-        //_lookupCache.invalidateAll();
-        //_validValuesCache.invalidateAll();
+        _lookupCache.removeAll();
+        _validValuesCache.removeAll();
     }
 
     /**

--- a/src/main/java/com/imsweb/staging/StagingDataProvider.java
+++ b/src/main/java/com/imsweb/staging/StagingDataProvider.java
@@ -15,13 +15,14 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import org.cache2k.Cache;
+import org.cache2k.Cache2kBuilder;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
 
 import com.imsweb.decisionengine.ColumnDefinition.ColumnType;
 import com.imsweb.decisionengine.DataProvider;
@@ -70,19 +71,26 @@ public abstract class StagingDataProvider implements DataProvider {
     }
 
     // lookup cache
-    private LoadingCache<SchemaLookup, List<StagingSchema>> _lookupCache;
+    private Cache<SchemaLookup, List<StagingSchema>> _lookupCache;
     // site/hist cache
-    private LoadingCache<String, Set<String>> _validValuesCache;
+    private Cache<String, Set<String>> _validValuesCache;
 
     /**
      * Constructor loads all schemas and sets up cache
      */
     protected StagingDataProvider() {
         // cache schema lookups
-        _lookupCache = Caffeine.newBuilder().maximumSize(500).expireAfterWrite(10, TimeUnit.MINUTES).build(this::getSchemas);
+        _lookupCache = new Cache2kBuilder<SchemaLookup, List<StagingSchema>>() {}
+                .entryCapacity(500)
+                .expireAfterWrite(10, TimeUnit.MINUTES)    // expire/refresh after 5 minutes
+                .resilienceDuration(30, TimeUnit.SECONDS) // cope with at most 30 seconds
+                .loader(this::getSchemas)         // auto populating function
+                .build();
 
         // cache the valid values for certain tables including site and histology
-        _validValuesCache = Caffeine.newBuilder().build(this::getAllInputValues);
+        _validValuesCache = new Cache2kBuilder<String, Set<String>>() {}
+                .loader(this::getAllInputValues)         // auto populating function
+                .build();
     }
 
     /**
@@ -300,8 +308,9 @@ public abstract class StagingDataProvider implements DataProvider {
      * Clear the caches
      */
     public void invalidateCache() {
-        _lookupCache.invalidateAll();
-        _validValuesCache.invalidateAll();
+        // TODO not sure how to do this?
+        //_lookupCache.invalidateAll();
+        //_validValuesCache.invalidateAll();
     }
 
     /**

--- a/src/main/java/com/imsweb/staging/StagingDataProvider.java
+++ b/src/main/java/com/imsweb/staging/StagingDataProvider.java
@@ -82,14 +82,14 @@ public abstract class StagingDataProvider implements DataProvider {
         // cache schema lookups
         _lookupCache = new Cache2kBuilder<SchemaLookup, List<StagingSchema>>() {}
                 .entryCapacity(500)
-                .expireAfterWrite(10, TimeUnit.MINUTES)    // expire/refresh after 5 minutes
-                .resilienceDuration(30, TimeUnit.SECONDS) // cope with at most 30 seconds
-                .loader(this::getSchemas)         // auto populating function
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .resilienceDuration(30, TimeUnit.SECONDS)
+                .loader(this::getSchemas)
                 .build();
 
         // cache the valid values for certain tables including site and histology
         _validValuesCache = new Cache2kBuilder<String, Set<String>>() {}
-                .loader(this::getAllInputValues)         // auto populating function
+                .loader(this::getAllInputValues)
                 .build();
     }
 


### PR DESCRIPTION
The library is currently using [Caffeine](https://github.com/ben-manes/caffeine).  That library still uses `sun.misc.Unsafe`.  There is an issue to look into it (https://github.com/ben-manes/caffeine/issues/273), but there has been no movement. 

This merge request switches the caching library to [Cache2k](https://cache2k.org) which has no deprecated dependencies and it fully compatible with Java 9+.