### PR TITLE
Switch cache to expiringmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ Download [the latest JAR][1] or grab via Maven:
 <dependency>
     <groupId>com.imsweb</groupId>
     <artifactId>staging-client-java</artifactId>
-    <version>4.6</version>
+    <version>4.7</version>
 </dependency>
 ```
 
 or via Gradle:
 
 ```groovy
-compile 'com.imsweb.com:staging-client-java:4.6'
+compile 'com.imsweb.com:staging-client-java:4.7'
 ```
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.imsweb'
-version = '4.7.1-SNAPSHOT'
+version = '4.7.2-SNAPSHOT'
 description = 'Java client library for staging calculations'
 
 // fail the build if there are compiler warnings
@@ -36,7 +36,9 @@ dependencies {
     // morphia annotations to make it easier to use in SEER*API
     api 'dev.morphia.morphia:core:1.5.1'
 
-    implementation 'net.jodah:expiringmap:0.5.9'
+    implementation "org.cache2k:cache2k-api:1.2.0.Final"
+    implementation "org.cache2k:cache2k-core:1.2.0.Final"
+    
     implementation 'org.apache.commons:commons-lang3:3.7'
 
     testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.imsweb'
-version = '4.6'
+version = '4.7-SNAPSHOT'
 description = 'Java client library for staging calculations'
 
 // fail the build if there are compiler warnings
@@ -36,9 +36,7 @@ dependencies {
     // morphia annotations to make it easier to use in SEER*API
     api 'dev.morphia.morphia:core:1.5.1'
 
-    implementation "org.cache2k:cache2k-api:1.2.0.Final"
-    implementation "org.cache2k:cache2k-core:1.2.0.Final"
-    
+    implementation 'net.jodah:expiringmap:0.5.9'
     implementation 'org.apache.commons:commons-lang3:3.7'
 
     testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.imsweb'
-version = '4.7-SNAPSHOT'
+version = '4.7.1-SNAPSHOT'
 description = 'Java client library for staging calculations'
 
 // fail the build if there are compiler warnings

--- a/src/main/java/com/imsweb/staging/StagingDataProvider.java
+++ b/src/main/java/com/imsweb/staging/StagingDataProvider.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
-import net.jodah.expiringmap.ExpirationPolicy;
 import net.jodah.expiringmap.ExpiringMap;
 
 import com.imsweb.decisionengine.ColumnDefinition.ColumnType;
@@ -80,7 +79,6 @@ public abstract class StagingDataProvider implements DataProvider {
     protected StagingDataProvider() {
         _lookupCache = ExpiringMap.builder()
                 .maxSize(500)
-                .expirationPolicy(ExpirationPolicy.ACCESSED)
                 .entryLoader(this::getSchemas)
                 .build();
 


### PR DESCRIPTION
Closes #62 

Cache2k was overkill for the simple use case in this library.  Switching to [expiringmap](https://github.com/jhalterman/expiringmap) which is lighter and also support LRU expiration.