### PR TITLE
Input context trimming

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id "io.codearte.nexus-staging" version "0.30.0"  // logs into Sonotype OSS and does a "Close" and "Release"
-    id 'com.adarshr.test-logger' version '2.1.1'
+    id 'com.adarshr.test-logger' version '3.0.0'
     id "com.github.ben-manes.versions" version "0.38.0"
     id 'org.sonatype.gradle.plugins.scan' version '2.0.7'
 }
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    spotbugs 'com.github.spotbugs:spotbugs:4.2.2'
+    spotbugs 'com.github.spotbugs:spotbugs:4.2.3'
 
     api "com.fasterxml.jackson.core:jackson-core:2.12.3"
     api "com.fasterxml.jackson.core:jackson-annotations:2.12.3"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id "io.codearte.nexus-staging" version "0.30.0"  // logs into Sonotype OSS and does a "Close" and "Release"
     id 'com.adarshr.test-logger' version '2.1.1'
     id "com.github.ben-manes.versions" version "0.38.0"
-    id 'org.sonatype.gradle.plugins.scan' version '2.0.5'
+    id 'org.sonatype.gradle.plugins.scan' version '2.0.7'
 }
 
 group = 'com.imsweb'
@@ -39,9 +39,9 @@ repositories {
 dependencies {
     spotbugs 'com.github.spotbugs:spotbugs:4.2.2'
 
-    api "com.fasterxml.jackson.core:jackson-core:2.12.2"
-    api "com.fasterxml.jackson.core:jackson-annotations:2.12.2"
-    api "com.fasterxml.jackson.core:jackson-databind:2.12.2"
+    api "com.fasterxml.jackson.core:jackson-core:2.12.3"
+    api "com.fasterxml.jackson.core:jackson-annotations:2.12.3"
+    api "com.fasterxml.jackson.core:jackson-databind:2.12.3"
 
     // morphia annotations to make it easier to use in SEER*API
     api 'dev.morphia.morphia:core:1.5.8'
@@ -196,6 +196,6 @@ nexusStaging {
 }
 
 wrapper {
-    gradleVersion = '6.8.3'
+    gradleVersion = '7.0'
     distributionType = Wrapper.DistributionType.ALL
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Closes #75 

At the end of the staging process, the results need to have field that were used as input removed from the list.  However we should not have been removing fields that were also defined as output field.  