### PR TITLE
Include algorithm ZIP file artifacts in release

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,13 +44,3 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew build sonarqube
-
-      - name: Create algorithm zips
-        if: ${{startsWith(github.ref, 'refs/tags/v') }}
-        run: ./gradlew zipAlgorithms
-
-      - name: Add algorithms to release
-        uses: softprops/action-gh-release@v1
-        if: ${{startsWith(github.ref, 'refs/tags/v') }}
-        with:
-          files: build/algorithms/*.zip

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,7 +45,8 @@ jobs:
           chmod +x gradlew
           ./gradlew build sonarqube
 
-      - name: Create algorithm zips
+      - name: Create algorithm zips (release only)
+        if: ${{startsWith(github.ref, 'refs/tags/') }}
         run: ./gradlew zipAlgorithms
 
       - name: Upload binaries (release only)

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,13 +44,3 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew build sonarqube
-
-      - name: Create algorithm zips (release only)
-        if: ${{startsWith(github.ref, 'refs/tags/v') }}
-        run: ./gradlew zipAlgorithms
-
-      - name: Upload binaries (release only)
-        uses: softprops/action-gh-release@v1
-        if: ${{startsWith(github.ref, 'refs/tags/v') }}
-        with:
-          files: build/algorithms/*.zip

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,11 +46,11 @@ jobs:
           ./gradlew build sonarqube
 
       - name: Create algorithm zips (release only)
-        if: ${{startsWith(github.ref, 'refs/tags/') }}
+        if: ${{startsWith(github.ref, 'refs/tags/v') }}
         run: ./gradlew zipAlgorithms
 
       - name: Upload binaries (release only)
         uses: softprops/action-gh-release@v1
-        if: ${{startsWith(github.ref, 'refs/tags/') }}
+        if: ${{startsWith(github.ref, 'refs/tags/v') }}
         with:
           files: build/algorithms/*.zip

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,8 +45,8 @@ jobs:
           chmod +x gradlew
           ./gradlew build sonarqube
 
-      - name: Verify algorithm zip
-        run: ls build/algorithms
+      - name: Create algorithm zips
+        run: ./gradlew zipAlgorithms
 
       - name: Upload binaries (release only)
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,3 +44,13 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew build sonarqube
+
+      - name: Create algorithm zips
+        if: ${{startsWith(github.ref, 'refs/tags/v') }}
+        run: ./gradlew zipAlgorithms
+
+      - name: Add algorithms to release
+        uses: softprops/action-gh-release@v1
+        if: ${{startsWith(github.ref, 'refs/tags/v') }}
+        with:
+          files: build/algorithms/*.zip

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,3 +45,8 @@ jobs:
           chmod +x gradlew
           ./gradlew build sonarqube
 
+      - name: Upload binaries (release only)
+        uses: softprops/action-gh-release@v1
+        if: ${{startsWith(github.ref, 'refs/tags/') }}
+        with:
+          files: build/algorithms/*.zip

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,6 +45,9 @@ jobs:
           chmod +x gradlew
           ./gradlew build sonarqube
 
+      - name: Verify algorithm zip
+        run: ls build/algorithms
+
       - name: Upload binaries (release only)
         uses: softprops/action-gh-release@v1
         if: ${{startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,13 +32,3 @@ jobs:
           ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SEER_GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SEER_GPG_PASSWORD }}
-
-      - name: Create algorithm zips
-        if: ${{startsWith(github.ref, 'refs/tags/v') }}
-        run: ./gradlew zipAlgorithms
-
-      - name: Add algorithms to release
-        uses: softprops/action-gh-release@v1
-        if: ${{startsWith(github.ref, 'refs/tags/v') }}
-        with:
-          files: build/algorithms/*.zip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '17'
+
       - name: Publish
         run: |
           chmod +x gradlew
@@ -30,3 +32,13 @@ jobs:
           ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SEER_GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SEER_GPG_PASSWORD }}
+
+      - name: Create algorithm zips
+        if: ${{startsWith(github.ref, 'refs/tags/v') }}
+        run: ./gradlew zipAlgorithms
+
+      - name: Add algorithms to release
+        uses: softprops/action-gh-release@v1
+        if: ${{startsWith(github.ref, 'refs/tags/v') }}
+        with:
+          files: build/algorithms/*.zip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
   repository_dispatch:
     types: manual-publish
   release:
-    types: [created]
+    types: [ created ]
 
 jobs:
   publish:

--- a/.github/workflows/upload-algorithms.yml
+++ b/.github/workflows/upload-algorithms.yml
@@ -1,0 +1,34 @@
+# Zip up algorithms and add to the release
+
+name: upload-algorithms
+
+on:
+  repository_dispatch:
+    types: manual-publish
+  release:
+    types: [ created ]
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+
+      - name: Create algorithm zips
+        if: ${{startsWith(github.ref, 'refs/tags/v') }}
+        run: ./gradlew zipAlgorithms
+
+      - name: Add algorithms to release
+        uses: softprops/action-gh-release@v1
+        if: ${{startsWith(github.ref, 'refs/tags/v') }}
+        with:
+          files: build/algorithms/*.zip

--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,13 @@ task csIntegrationTest(type: JavaExec) {
     classpath = sourceSets.test.runtimeClasspath
 }
 
+// run the full CS integration test suite
+task zipAlgorithms(type: JavaExec) {
+    mainClass.set('com.imsweb.staging.zip.ZipAlgorithms')
+    classpath = sourceSets.test.runtimeClasspath
+}
+check.dependsOn 'zipAlgorithms'
+
 // don't try to release a snapshot to a non-snapshot repository, that won't work anyway
 if (version.endsWith('-SNAPSHOT')) {
     gradle.startParameter.excludedTaskNames += 'signMavenJavaPublication'

--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,6 @@ task zipAlgorithms(type: JavaExec) {
     mainClass.set('com.imsweb.staging.zip.ZipAlgorithms')
     classpath = sourceSets.test.runtimeClasspath
 }
-check.dependsOn 'zipAlgorithms'
 
 // don't try to release a snapshot to a non-snapshot repository, that won't work anyway
 if (version.endsWith('-SNAPSHOT')) {

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     testImplementation 'org.slf4j:slf4j-simple:1.7.36'
     testImplementation 'com.google.code.bean-matchers:bean-matchers:0.13'
     testImplementation 'com.imsweb:seerapi-client-java:5.1'
-
+    testImplementation 'org.zeroturnaround:zt-zip:1.15'
 }
 
 jar {

--- a/src/test/java/com/imsweb/staging/zip/ZipAlgorithms.java
+++ b/src/test/java/com/imsweb/staging/zip/ZipAlgorithms.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Information Management Services, Inc.
+ */
+package com.imsweb.staging.zip;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.zeroturnaround.zip.ZipUtil;
+
+import com.imsweb.staging.cs.CsDataProvider.CsVersion;
+import com.imsweb.staging.eod.EodDataProvider.EodVersion;
+import com.imsweb.staging.tnm.TnmDataProvider.TnmVersion;
+
+/**
+ * Create ZIP files of algorithms to include in releases
+ */
+public class ZipAlgorithms {
+
+    public static void main(String[] args) throws IOException {
+        zipAlgorithm("cs", CsVersion.LATEST.getVersion());
+        zipAlgorithm("tnm", TnmVersion.LATEST.getVersion());
+        zipAlgorithm("eod_public", EodVersion.LATEST.getVersion());
+        //zipAlgorithm("toronto", TorontoVersion.LATEST.getVersion());
+    }
+
+    private static void zipAlgorithm(String algorithm, String version) throws IOException {
+        String algoDir = Paths.get("src", "main", "resources").toFile().getAbsolutePath() + "/algorithms/" + algorithm + "/" + version;
+        Path buildDir = Paths.get("build", "algorithms");
+        String outputFile = buildDir.toFile().getAbsolutePath() + "/" + algorithm + "-" + version + ".zip";
+
+        // make sure directory exists
+        Files.createDirectories(buildDir);
+
+        ZipUtil.pack(new File(algoDir), new File(outputFile));
+    }
+
+}

--- a/src/test/java/com/imsweb/staging/zip/ZipAlgorithms.java
+++ b/src/test/java/com/imsweb/staging/zip/ZipAlgorithms.java
@@ -9,6 +9,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.zeroturnaround.zip.ZipUtil;
 
 import com.imsweb.staging.cs.CsDataProvider.CsVersion;
@@ -20,6 +22,8 @@ import com.imsweb.staging.tnm.TnmDataProvider.TnmVersion;
  */
 public class ZipAlgorithms {
 
+    private static final Logger _LOG = LoggerFactory.getLogger(ZipAlgorithms.class);
+
     public static void main(String[] args) throws IOException {
         zipAlgorithm("cs", CsVersion.LATEST.getVersion());
         zipAlgorithm("tnm", TnmVersion.LATEST.getVersion());
@@ -28,14 +32,16 @@ public class ZipAlgorithms {
     }
 
     private static void zipAlgorithm(String algorithm, String version) throws IOException {
-        String algoDir = Paths.get("src", "main", "resources").toFile().getAbsolutePath() + "/algorithms/" + algorithm + "/" + version;
+        Path algoDir = Paths.get("src", "main", "resources", "algorithms", algorithm, version);
         Path buildDir = Paths.get("build", "algorithms");
-        String outputFile = buildDir.toFile().getAbsolutePath() + "/" + algorithm + "-" + version + ".zip";
+        String outputFile = buildDir.toFile().getAbsolutePath() + File.separatorChar + algorithm + "-" + version + ".zip";
 
         // make sure directory exists
         Files.createDirectories(buildDir);
 
-        ZipUtil.pack(new File(algoDir), new File(outputFile));
+        ZipUtil.pack(new File(algoDir.toFile().getAbsolutePath()), new File(outputFile));
+
+        _LOG.info("Created " + outputFile);
     }
 
 }


### PR DESCRIPTION
This adds a task and CI setup to run automatically on releases.  It will

- create ZIP files of all the algorithms.
- upload the algorithm ZIPs as artifacts to the release

This will allow users to more easily access older versions of algorithms since the library only contains the latest one.  With the ZIP file, the `Staging` instance can be created with `ExternalStagingFileDataProvider`. 

See https://github.com/imsweb/staging-client-java#get-a-staging-instance.