### PR TITLE
Add 3 new fields to Table

### DIFF
--- a/.github/workflows/cs-comparison.yml
+++ b/.github/workflows/cs-comparison.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '17'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,19 +11,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '17'
           cache: 'gradle'
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '17'

--- a/.github/workflows/upload-algorithms.yml
+++ b/.github/workflows/upload-algorithms.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '17'

--- a/lib/src/main/java/com/imsweb/staging/Staging.java
+++ b/lib/src/main/java/com/imsweb/staging/Staging.java
@@ -180,6 +180,9 @@ public final class Staging {
             addGlossaryMatches(hits, table.getSubtitle());
             addGlossaryMatches(hits, table.getNotes());
             addGlossaryMatches(hits, table.getFootnotes());
+            addGlossaryMatches(hits, table.getRational());
+            addGlossaryMatches(hits, table.getAdditionalInfo());
+            addGlossaryMatches(hits, table.getCodingGuidelines());
 
             // add any DESCRIPTION columns glossary matches
             if (table.getColumnDefinitions() != null && table.getRawRows() != null) {

--- a/lib/src/main/java/com/imsweb/staging/entities/Table.java
+++ b/lib/src/main/java/com/imsweb/staging/entities/Table.java
@@ -34,6 +34,12 @@ public interface Table {
 
     String getFootnotes();
 
+    String getRational();
+
+    String getAdditionalInfo();
+
+    String getCodingGuidelines();
+
     Date getLastModified();
 
     /**

--- a/lib/src/main/java/com/imsweb/staging/entities/impl/StagingTable.java
+++ b/lib/src/main/java/com/imsweb/staging/entities/impl/StagingTable.java
@@ -18,7 +18,8 @@ import com.imsweb.staging.entities.ColumnDefinition.ColumnType;
 import com.imsweb.staging.entities.Table;
 import com.imsweb.staging.entities.TableRow;
 
-@JsonPropertyOrder({"id", "algorithm", "version", "name", "title", "subtitle", "description", "notes", "footnotes", "last_modified", "definition", "extra_input", "rows"})
+@JsonPropertyOrder({"id", "algorithm", "version", "name", "title", "subtitle", "description", "notes", "rational", "additional_info", "coding_guildlines", "footnotes",
+        "last_modified", "definition", "extra_input", "rows"})
 public class StagingTable implements Table {
 
     private String _displayId;
@@ -30,6 +31,9 @@ public class StagingTable implements Table {
     private String _subtitle;
     private String _notes;
     private String _footnotes;
+    private String _rational;
+    private String _additionalInfo;
+    private String _codingGuidelines;
     private Date _lastModified;
     private List<StagingColumnDefinition> _definition;
     private Set<String> _extraInput;
@@ -136,6 +140,36 @@ public class StagingTable implements Table {
 
     public void setFootnotes(String footnotes) {
         _footnotes = footnotes;
+    }
+
+    @Override
+    @JsonProperty("rational")
+    public String getRational() {
+        return _rational;
+    }
+
+    public void setRational(String rational) {
+        _rational = rational;
+    }
+
+    @Override
+    @JsonProperty("additional_info")
+    public String getAdditionalInfo() {
+        return _additionalInfo;
+    }
+
+    public void setAdditonalInfo(String additionalInformation) {
+        _additionalInfo = additionalInformation;
+    }
+
+    @Override
+    @JsonProperty("coding_guidelines")
+    public String getCodingGuidelines() {
+        return _codingGuidelines;
+    }
+
+    public void setCodingGuidelines(String codingGuidelines) {
+        _codingGuidelines = codingGuidelines;
     }
 
     @Override

--- a/lib/src/main/java/com/imsweb/staging/entities/impl/StagingTable.java
+++ b/lib/src/main/java/com/imsweb/staging/entities/impl/StagingTable.java
@@ -158,7 +158,7 @@ public class StagingTable implements Table {
         return _additionalInfo;
     }
 
-    public void setAdditonalInfo(String additionalInformation) {
+    public void setAdditionalInfo(String additionalInformation) {
         _additionalInfo = additionalInformation;
     }
 
@@ -270,6 +270,9 @@ public class StagingTable implements Table {
                 Objects.equals(_subtitle, table._subtitle) &&
                 Objects.equals(_notes, table._notes) &&
                 Objects.equals(_footnotes, table._footnotes) &&
+                Objects.equals(_rational, table._rational) &&
+                Objects.equals(_additionalInfo, table._additionalInfo) &&
+                Objects.equals(_codingGuidelines, table._codingGuidelines) &&
                 Objects.equals(_definition, table._definition) &&
                 Objects.equals(_extraInput, table._extraInput) &&
                 Objects.equals(_rows, table._rows);
@@ -278,6 +281,7 @@ public class StagingTable implements Table {
     @Override
     public int hashCode() {
         // intentionally does not include _id, _lastModified, _parsedTableRows
-        return Objects.hash(_displayId, _algorithm, _version, _name, _title, _description, _subtitle, _notes, _footnotes, _definition, _extraInput, _rows);
+        return Objects.hash(_displayId, _algorithm, _version, _name, _title, _description, _subtitle, _notes, _footnotes, _rational, _additionalInfo,
+                _codingGuidelines, _definition, _extraInput, _rows);
     }
 }


### PR DESCRIPTION
Adding 3 additional documentation type fields to the `Table` interface. These fields have no affect on calculations.

- Rational
- Additional Information
- Coding Instructions

Note that this does not actually add values to these field; only a place to store them. After this is released, SEER\*API will be updated and work will continue to add data. Eventually another release of this library will include those values.