### PR TITLE
Tweaks to table row matching with numerics

### DIFF
--- a/algorithm-eod/src/test/java/com/imsweb/staging/eod/EodStagingTest.java
+++ b/algorithm-eod/src/test/java/com/imsweb/staging/eod/EodStagingTest.java
@@ -215,6 +215,14 @@ class EodStagingTest extends StagingTest {
     }
 
     @Test
+    void testFindTableRowDecimal() {
+        // only do float comparison of ranges if the low or high vaslues have a decimal
+        assertThat(_STAGING.findMatchingTableRow("age_at_diagnosis_validation_65093", "age_dx", "10.5")).isNull();
+
+        assertThat(_STAGING.findMatchingTableRow("age_at_diagnosis_validation_65093", "age_dx", "10")).isNotNull();
+    }
+
+    @Test
     void testStagePancreas() {
         EodStagingData data = new EodStagingInputBuilder()
                 .withInput(EodInput.DX_YEAR, "2018")

--- a/lib/src/main/java/com/imsweb/staging/entities/impl/StagingRange.java
+++ b/lib/src/main/java/com/imsweb/staging/entities/impl/StagingRange.java
@@ -81,9 +81,13 @@ public class StagingRange implements Range {
         String low = DecisionEngine.translateValue(_low, context);
         String high = DecisionEngine.translateValue(_high, context);
 
-        // if input, low and high values represent decimal numbers then do a float comparison
+        // if input, low and high values represent numbers then do a float comparison
         if (!low.equals(high) && NumberUtils.isParsable(low) && NumberUtils.isParsable(high)) {
             if (!NumberUtils.isParsable(value))
+                return false;
+
+            // if the numeric range is not using decimals then don't allow the value to match with a decimal
+            if (!(low.contains(".") || high.contains(".")) && value.contains("."))
                 return false;
 
             Float converted = NumberUtils.createFloat(value);

--- a/lib/src/test/java/com/imsweb/staging/entities/StagingRangeTest.java
+++ b/lib/src/test/java/com/imsweb/staging/entities/StagingRangeTest.java
@@ -96,6 +96,10 @@ class StagingRangeTest {
         // nothing checks that a decimal is there.  Non-decimal value will still be considered in the range.
         assertTrue(new StagingRange("0.1", "99999.9").contains("1000", new HashMap<>()));
 
+        // however if the range do not contain decimals, then do not allow a mtch on decimals
+        assertFalse(new StagingRange("001", "999").contains("10.5", new HashMap<>()));
+        assertTrue(new StagingRange("001", "999").contains("10", new HashMap<>()));
+
         assertFalse(new StagingRange("1.0", "999.999").contains("0.1", new HashMap<>()));
         assertTrue(new StagingRange("1.0", "999.999").contains("1.000001", new HashMap<>()));
         assertTrue(new StagingRange("1.0", "999.999").contains("1.9", new HashMap<>()));

--- a/lib/src/test/java/com/imsweb/staging/entities/StagingRangeTest.java
+++ b/lib/src/test/java/com/imsweb/staging/entities/StagingRangeTest.java
@@ -98,6 +98,8 @@ class StagingRangeTest {
 
         // however if the range do not contain decimals, then do not allow a mtch on decimals
         assertFalse(new StagingRange("001", "999").contains("10.5", new HashMap<>()));
+        assertTrue(new StagingRange("001.1", "999").contains("10.5", new HashMap<>()));
+        assertTrue(new StagingRange("001", "999.99").contains("10.5", new HashMap<>()));
         assertTrue(new StagingRange("001", "999").contains("10", new HashMap<>()));
 
         assertFalse(new StagingRange("1.0", "999.999").contains("0.1", new HashMap<>()));


### PR DESCRIPTION
When matching table rows, we are using a float comparison for ranges. That means that we can find a match for a decimal value for a purely integer range. That is not what was intended.

For example, if a table had a row defined like this:

```
"rows" : [ [ "000-120,999" ] ]
```

If you tried to match "35.5" it would find a match because it was just doing a float compare between "0" and "120". However since that is not a decimal comparison it should not have found a match. This issue changes so that if neither the high or low value have a decimal point and the value it is using to compare does, then it will not find a match. So "35.5" would not find a match.