### PR TITLE
Added "default_table" to involved tables

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -3,19 +3,19 @@ plugins {
 }
 
 dependencies {
-    api "com.fasterxml.jackson.core:jackson-core:2.19.0"
-    api "com.fasterxml.jackson.core:jackson-annotations:2.19.0"
-    api "com.fasterxml.jackson.core:jackson-databind:2.19.0"
+    api "com.fasterxml.jackson.core:jackson-core:2.19.1"
+    api "com.fasterxml.jackson.core:jackson-annotations:2.19.1"
+    api "com.fasterxml.jackson.core:jackson-databind:2.19.1"
 
     implementation "org.cache2k:cache2k-api:2.6.1.Final"
     runtimeOnly "org.cache2k:cache2k-core:2.6.1.Final"
 
-    implementation 'org.apache.commons:commons-lang3:3.17.0'
+    implementation 'org.apache.commons:commons-lang3:3.18.0'
     implementation 'org.ahocorasick:ahocorasick:0.6.3'
 
     implementation 'org.slf4j:slf4j-api:2.0.17'
 
-    testFixturesImplementation 'com.imsweb:seerapi-client-java:5.8'
+    testFixturesImplementation 'com.imsweb:seerapi-client-java:5.9'
     testFixturesImplementation 'org.slf4j:slf4j-simple:2.0.17'
     testFixturesImplementation 'org.zeroturnaround:zt-zip:1.17'
     testFixturesImplementation 'org.junit.jupiter:junit-jupiter-api:5.12.2'

--- a/lib/src/main/java/com/imsweb/staging/engine/DecisionEngine.java
+++ b/lib/src/main/java/com/imsweb/staging/engine/DecisionEngine.java
@@ -343,6 +343,8 @@ public class DecisionEngine {
             Input input = schema.getInputMap().get(key);
             if (input.getTable() != null)
                 getInvolvedTables(getProvider().getTable(input.getTable()), tables);
+            if (input.getDefaultTable() != null)
+                getInvolvedTables(getProvider().getTable(input.getDefaultTable()), tables);
         }
         for (String key : schema.getOutputMap().keySet()) {
             Output output = schema.getOutputMap().get(key);

--- a/lib/src/test/java/com/imsweb/staging/engine/DecisionEngineTest.java
+++ b/lib/src/test/java/com/imsweb/staging/engine/DecisionEngineTest.java
@@ -1595,6 +1595,10 @@ public class DecisionEngineTest {
 
         DecisionEngine engine = new DecisionEngine(provider);
 
+        // first, verify getInvolvedTables is working with default tables
+        Set<String> tables = engine.getInvolvedTables("test_default_table");
+        assertThat(tables).containsExactlyInAnyOrder("table_input1", "table_input2", "table_input2_default", "table_mapping");
+
         // test a case where the default_table make a successful lookup
         Map<String, String> context = new HashMap<>();
         context.put("input1", "000");


### PR DESCRIPTION
When default tables were added in #118, they were not added to the involved tables method. That was an oversight.

commons-lang was also updated to fix vulnerability.